### PR TITLE
remember dark and desktop modes settings per domain

### DIFF
--- a/app/src/main/java/acr/browser/lightning/database/HostsList.kt
+++ b/app/src/main/java/acr/browser/lightning/database/HostsList.kt
@@ -1,0 +1,45 @@
+package acr.browser.lightning.database
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.net.Uri
+
+// generic list of hosts backed by a shared preferences file
+//  use for persistent storage of sites for dark mode, blocking/allowing js or ads, maybe other things
+class HostsList(applicationContext: Context, pref: String) {
+    val prefs: SharedPreferences = applicationContext.getSharedPreferences(pref, Context.MODE_PRIVATE)
+
+    fun add(url: String, tf: Boolean) {
+        val host = url.host() ?: return // should there be some error message?
+        prefs.edit().putBoolean(host, tf).apply()
+    }
+
+    fun exists(url: String): Boolean {
+        val host = url.host() ?: return false
+        return prefs.contains(host)
+    }
+
+    fun get(url: Uri, default: Boolean): Boolean {
+        val host = url.host ?: return default
+        return prefs.getBoolean(host, default)
+    }
+
+    fun get(url: String, default: Boolean): Boolean {
+        return get(Uri.parse(url), default)
+    }
+
+    fun remove(url: String) {
+        val host = url.host() ?: return
+        prefs.edit().remove(host).apply()
+    }
+
+    fun clear() = prefs.edit().clear().apply()
+
+    fun String.host(): String? = Uri.parse(this).host
+
+    companion object {
+        const val DARK_MODE = "dark_mode"
+        const val DESKTOP_MODE = "desktop_mode"
+    }
+}
+ 

--- a/app/src/main/java/acr/browser/lightning/view/LightningView.kt
+++ b/app/src/main/java/acr/browser/lightning/view/LightningView.kt
@@ -9,6 +9,7 @@ import acr.browser.lightning.R
 import acr.browser.lightning.browser.TabModel
 import acr.browser.lightning.constant.*
 import acr.browser.lightning.controller.UIController
+import acr.browser.lightning.database.HostsList
 import acr.browser.lightning.di.DatabaseScheduler
 import acr.browser.lightning.di.MainScheduler
 import acr.browser.lightning.di.injector
@@ -170,6 +171,8 @@ class LightningView(
             }
         }
 
+    val desktopModeList = HostsList(activity.applicationContext, HostsList.DESKTOP_MODE)
+
     /**
      *
      */
@@ -178,6 +181,8 @@ class LightningView(
             field = aDarkMode
             applyDarkMode();
         }
+
+    val darkModeList = HostsList(activity.applicationContext, HostsList.DARK_MODE)
 
     /**
      *
@@ -302,8 +307,8 @@ class LightningView(
             //TODO: it looks like our special URLs don't get frozen for some reason
             createWebView()
             initializeContent(tabInitializer)
-            desktopMode = userPreferences.desktopModeDefault
-            darkMode = userPreferences.darkModeDefault
+            desktopMode = desktopModeList.get(tabInitializer.url(), userPreferences.desktopModeDefault)
+            darkMode = darkModeList.get(tabInitializer.url(), userPreferences.darkModeDefault)
         } else {
             // Our WebView will only be created whenever our tab goes to the foreground
             latentTabInitializer = tabInitializer
@@ -593,6 +598,16 @@ class LightningView(
     fun toggleDesktopUserAgent() {
         // Toggle desktop mode
         desktopMode = !desktopMode
+        if (desktopMode != userPreferences.desktopModeDefault)
+            desktopModeList.add(url, desktopMode)
+        else
+            desktopModeList.remove(url)
+    }
+
+    fun updateDesktopMode() {
+        val newDesktopMode = desktopModeList.get(url, userPreferences.desktopModeDefault)
+        if (newDesktopMode != desktopMode)
+            desktopMode = newDesktopMode
     }
 
     /**
@@ -601,8 +616,17 @@ class LightningView(
     fun toggleDarkMode() {
         // Toggle dark mode
         darkMode = !darkMode
+        if (darkMode != userPreferences.darkModeDefault)
+            darkModeList.add(url, darkMode)
+        else
+            darkModeList.remove(url)
     }
 
+    fun updateDarkMode() {
+        val newDarkMode = darkModeList.get(url, userPreferences.darkModeDefault)
+        if (newDarkMode != darkMode)
+            darkMode = newDarkMode
+    }
 
     /**
      * This method sets the user agent of the current tab based on the user's preference

--- a/app/src/main/java/acr/browser/lightning/view/LightningWebClient.kt
+++ b/app/src/main/java/acr/browser/lightning/view/LightningWebClient.kt
@@ -178,6 +178,8 @@ class LightningWebClient(
      */
     override fun onPageStarted(view: WebView, url: String, favicon: Bitmap?) {
         currentUrl = url
+        lightningView.updateDarkMode()
+        lightningView.updateDesktopMode()
         // Only set the SSL state if there isn't an error for the current URL.
         if (urlWithSslError != url) {
             sslState = if (URLUtil.isHttpsUrl(url)) {


### PR DESCRIPTION
This adresses part of #159 
With this PR, desktop and dark mode settings are stored for each host.
On load, the settings are applied within `onPageStarted`, which I found to give the best experience (effect is shown once the new page is visible, but not on the old page)

Storage is done using shared preferences, and state is only stored if setting deviates from default mode (at time of storage).

The `HostList` should be extendable for other settings mentioned in #159, and I find it easier to handle than an SQLite db.