### PR TITLE
Maybe fix crash in #221

### DIFF
--- a/app/src/main/java/acr/browser/lightning/adblock/BloomFilterAdBlocker.kt
+++ b/app/src/main/java/acr/browser/lightning/adblock/BloomFilterAdBlocker.kt
@@ -1,5 +1,6 @@
 package acr.browser.lightning.adblock
 
+/*
 import acr.browser.lightning.R
 import acr.browser.lightning.adblock.source.HostsDataSourceProvider
 import acr.browser.lightning.adblock.source.HostsResult
@@ -180,3 +181,4 @@ class BloomFilterAdBlocker @Inject constructor(
     }
 
 }
+*/

--- a/app/src/main/java/acr/browser/lightning/adblock/source/AssetsHostsDataSource.kt
+++ b/app/src/main/java/acr/browser/lightning/adblock/source/AssetsHostsDataSource.kt
@@ -13,6 +13,7 @@ import java.io.InputStreamReader
  * @param assetManager The store for application assets.
  * @param logger The logger used to log status.
  */
+/*
 class AssetsHostsDataSource constructor(
     private val assetManager: AssetManager,
     private val logger: Logger
@@ -44,3 +45,4 @@ class AssetsHostsDataSource constructor(
     }
 
 }
+*/

--- a/app/src/main/java/acr/browser/lightning/adblock/source/FileHostsDataSource.kt
+++ b/app/src/main/java/acr/browser/lightning/adblock/source/FileHostsDataSource.kt
@@ -15,6 +15,7 @@ import java.io.InputStreamReader
  * @param logger The logger used to log information about the loading process.
  * @param file The file from which hosts will be loaded. Must have read access to the file.
  */
+/*
 class FileHostsDataSource constructor(
     private val logger: Logger,
     private val file: File
@@ -45,3 +46,4 @@ class FileHostsDataSource constructor(
     }
 
 }
+*/

--- a/app/src/main/java/acr/browser/lightning/adblock/source/HostsDataSource.kt
+++ b/app/src/main/java/acr/browser/lightning/adblock/source/HostsDataSource.kt
@@ -5,7 +5,7 @@ import io.reactivex.Single
 /**
  * A data source that contains hosts.
  */
-interface HostsDataSource {
+/*interface HostsDataSource {
 
     /**
      * Load the hosts and emit them as a [Single] [HostsResult].
@@ -18,3 +18,4 @@ interface HostsDataSource {
     fun identifier(): String
 
 }
+*/

--- a/app/src/main/java/acr/browser/lightning/adblock/source/HostsDataSourceProvider.kt
+++ b/app/src/main/java/acr/browser/lightning/adblock/source/HostsDataSourceProvider.kt
@@ -3,6 +3,7 @@ package acr.browser.lightning.adblock.source
 /**
  * The provider for the hosts data source.
  */
+/*
 interface HostsDataSourceProvider {
 
     /**
@@ -11,3 +12,4 @@ interface HostsDataSourceProvider {
     fun createHostsDataSource(): HostsDataSource
 
 }
+*/

--- a/app/src/main/java/acr/browser/lightning/adblock/source/HostsResult.kt
+++ b/app/src/main/java/acr/browser/lightning/adblock/source/HostsResult.kt
@@ -5,6 +5,7 @@ import acr.browser.lightning.database.adblock.Host
 /**
  * The result of a request for the hosts to block.
  */
+/*
 sealed class HostsResult {
 
     /**
@@ -22,3 +23,4 @@ sealed class HostsResult {
     data class Failure(val cause: Exception) : HostsResult()
 
 }
+*/

--- a/app/src/main/java/acr/browser/lightning/adblock/source/HostsSourceType.kt
+++ b/app/src/main/java/acr/browser/lightning/adblock/source/HostsSourceType.kt
@@ -9,6 +9,7 @@ import java.io.File
 /**
  * The source from which hosts should be loaded.
  */
+/*
 sealed class HostsSourceType {
 
     /**
@@ -59,3 +60,4 @@ fun HostsSourceType.toPreferenceIndex(): Int = when (this) {
     is HostsSourceType.Local -> 1
     is HostsSourceType.Remote -> 2
 }
+*/

--- a/app/src/main/java/acr/browser/lightning/adblock/source/PreferencesHostsDataSourceProvider.kt
+++ b/app/src/main/java/acr/browser/lightning/adblock/source/PreferencesHostsDataSourceProvider.kt
@@ -13,6 +13,7 @@ import javax.inject.Inject
 /**
  * A [HostsDataSourceProvider] backed by [UserPreferences].
  */
+/*
 @Reusable
 class PreferencesHostsDataSourceProvider @Inject constructor(
     private val userPreferences: UserPreferences,
@@ -30,3 +31,4 @@ class PreferencesHostsDataSourceProvider @Inject constructor(
         }
 
 }
+*/

--- a/app/src/main/java/acr/browser/lightning/adblock/source/UrlHostsDataSource.kt
+++ b/app/src/main/java/acr/browser/lightning/adblock/source/UrlHostsDataSource.kt
@@ -14,6 +14,7 @@ import java.io.InputStreamReader
 /**
  * A [HostsDataSource] that loads hosts from an [HttpUrl].
  */
+/*
 class UrlHostsDataSource(
     private val url: HttpUrl,
     private val okHttpClient: Single<OkHttpClient>,
@@ -60,3 +61,4 @@ class UrlHostsDataSource(
     }
 
 }
+*/

--- a/app/src/main/java/acr/browser/lightning/di/AppBindsModule.kt
+++ b/app/src/main/java/acr/browser/lightning/di/AppBindsModule.kt
@@ -2,10 +2,10 @@ package acr.browser.lightning.di
 
 import acr.browser.lightning.adblock.allowlist.AllowListModel
 import acr.browser.lightning.adblock.allowlist.SessionAllowListModel
-import acr.browser.lightning.adblock.source.AssetsHostsDataSource
-import acr.browser.lightning.adblock.source.HostsDataSource
-import acr.browser.lightning.adblock.source.HostsDataSourceProvider
-import acr.browser.lightning.adblock.source.PreferencesHostsDataSourceProvider
+//import acr.browser.lightning.adblock.source.AssetsHostsDataSource
+//import acr.browser.lightning.adblock.source.HostsDataSource
+//import acr.browser.lightning.adblock.source.HostsDataSourceProvider
+//import acr.browser.lightning.adblock.source.PreferencesHostsDataSourceProvider
 import acr.browser.lightning.browser.cleanup.DelegatingExitCleanup
 import acr.browser.lightning.browser.cleanup.ExitCleanup
 import acr.browser.lightning.database.adblock.UserRulesDatabase
@@ -52,15 +52,15 @@ interface AppBindsModule {
     @Binds
     fun bindsSslWarningPreferences(sessionSslWarningPreferences: SessionSslWarningPreferences): SslWarningPreferences
 
-    @Binds
+/*    @Binds
     fun bindsHostsDataSource(assetsHostsDataSource: AssetsHostsDataSource): HostsDataSource
 
     @Binds
     fun bindsHostsRepository(hostsDatabase: HostsDatabase): HostsRepository
-
+*/
     @Binds
     fun bindsAbpRulesRepository(apbRulesDatabase: UserRulesDatabase): UserRulesRepository
 
-    @Binds
-    fun bindsHostsDataSourceProvider(preferencesHostsDataSourceProvider: PreferencesHostsDataSourceProvider): HostsDataSourceProvider
+//    @Binds
+//    fun bindsHostsDataSourceProvider(preferencesHostsDataSourceProvider: PreferencesHostsDataSourceProvider): HostsDataSourceProvider
 }

--- a/app/src/main/java/acr/browser/lightning/di/AppComponent.kt
+++ b/app/src/main/java/acr/browser/lightning/di/AppComponent.kt
@@ -3,7 +3,7 @@ package acr.browser.lightning.di
 import acr.browser.lightning.BrowserApp
 import acr.browser.lightning.ThemedActivity
 import acr.browser.lightning.adblock.AbpBlocker
-import acr.browser.lightning.adblock.BloomFilterAdBlocker
+//import acr.browser.lightning.adblock.BloomFilterAdBlocker
 import acr.browser.lightning.adblock.NoOpAdBlocker
 import acr.browser.lightning.browser.MenuMain
 import acr.browser.lightning.browser.MenuWebPage
@@ -113,7 +113,7 @@ interface AppComponent {
 
     fun inject(bookmarksAdapter: BookmarksAdapter)
 
-    fun provideBloomFilterAdBlocker(): BloomFilterAdBlocker
+//    fun provideBloomFilterAdBlocker(): BloomFilterAdBlocker
     fun provideAbpAdBlocker(): AbpBlocker
 
     fun provideNoOpAdBlocker(): NoOpAdBlocker

--- a/app/src/main/java/acr/browser/lightning/settings/fragment/AdBlockSettingsFragment.kt
+++ b/app/src/main/java/acr/browser/lightning/settings/fragment/AdBlockSettingsFragment.kt
@@ -4,7 +4,7 @@ import acr.browser.lightning.R
 import acr.browser.lightning.adblock.AbpBlocker
 import acr.browser.lightning.adblock.AbpListUpdater
 import acr.browser.lightning.adblock.AbpUpdateMode
-import acr.browser.lightning.adblock.BloomFilterAdBlocker
+//import acr.browser.lightning.adblock.BloomFilterAdBlocker
 import acr.browser.lightning.constant.Schemes
 import acr.browser.lightning.di.DiskScheduler
 import acr.browser.lightning.di.MainScheduler
@@ -50,7 +50,7 @@ class AdBlockSettingsFragment : AbstractSettingsFragment() {
     @Inject internal lateinit var userPreferences: UserPreferences
     @Inject @field:MainScheduler internal lateinit var mainScheduler: Scheduler
     @Inject @field:DiskScheduler internal lateinit var diskScheduler: Scheduler
-    @Inject internal lateinit var bloomFilterAdBlocker: BloomFilterAdBlocker
+//    @Inject internal lateinit var bloomFilterAdBlocker: BloomFilterAdBlocker
     @Inject internal lateinit var abpListUpdater: AbpListUpdater
     @Inject internal lateinit var abpBlocker: AbpBlocker
 

--- a/app/src/main/java/acr/browser/lightning/settings/preferences/UserPreferences.kt
+++ b/app/src/main/java/acr/browser/lightning/settings/preferences/UserPreferences.kt
@@ -316,17 +316,17 @@ class UserPreferences @Inject constructor(
     /**
      * The index of the ad blocking hosts file source.
      */
-    var hostsSource by preferences.intPreference(HOSTS_SOURCE, 0)
+//    var hostsSource by preferences.intPreference(HOSTS_SOURCE, 0)
 
     /**
      * The local file from which ad blocking hosts should be read, depending on the [hostsSource].
      */
-    var hostsLocalFile by preferences.nullableStringPreference(HOSTS_LOCAL_FILE)
+//    var hostsLocalFile by preferences.nullableStringPreference(HOSTS_LOCAL_FILE)
 
     /**
      * The remote URL from which ad blocking hosts should be read, depending on the [hostsSource].
      */
-    var hostsRemoteFile by preferences.nullableStringPreference(HOSTS_REMOTE_FILE)
+//    var hostsRemoteFile by preferences.nullableStringPreference(HOSTS_REMOTE_FILE)
 
     /**
      * User can disable Firebase Google Analytics.


### PR DESCRIPTION
#221 appears to happen because the app is trying to access the old _hosts.txt_ file, which does not exists any more.
This PR does a bit more, it just removes/comments the old blocker and hosts source + provider, as they are not needed any more.

Unfortunately I don't have time to test whether this really helps, but since it removes the only occurence of _hosts.txt_, there can't be any access to the file.

If it helps, the files / parts should be removed instead of commented. I chose the quick way as I don't have much time (today and probably the next few days)

Still I'm a bit curious why this crash doesn't happen on my phone...