### PR TITLE
remove device name from default user agent

### DIFF
--- a/app/src/main/java/acr/browser/lightning/settings/fragment/GeneralSettingsFragment.kt
+++ b/app/src/main/java/acr/browser/lightning/settings/fragment/GeneralSettingsFragment.kt
@@ -338,6 +338,7 @@ class GeneralSettingsFragment : AbstractSettingsFragment() {
         7 -> resources.getString(R.string.agent_system)
         8 -> resources.getString(R.string.agent_web_view)
         9 -> resources.getString(R.string.agent_custom)
+        10 -> resources.getString(R.string.agent_hide_device)
         else -> resources.getString(R.string.agent_default)
     }
 
@@ -348,7 +349,7 @@ class GeneralSettingsFragment : AbstractSettingsFragment() {
                 setSingleChoiceItems(R.array.user_agent, userPreferences.userAgentChoice - 1) { _, which ->
                     userPreferences.userAgentChoice = which + 1
                     when (which) {
-                        in 0..7 -> Unit
+                        in 0..7, 9 -> Unit
                         8 -> {
                             showCustomUserAgentPicker()
                         }

--- a/app/src/main/java/acr/browser/lightning/settings/preferences/UserPreferencesExtensions.kt
+++ b/app/src/main/java/acr/browser/lightning/settings/preferences/UserPreferencesExtensions.kt
@@ -2,6 +2,7 @@ package acr.browser.lightning.settings.preferences
 
 import acr.browser.lightning.constant.*
 import android.app.Application
+import android.os.Build
 import android.webkit.WebSettings
 
 /**

--- a/app/src/main/java/acr/browser/lightning/settings/preferences/UserPreferencesExtensions.kt
+++ b/app/src/main/java/acr/browser/lightning/settings/preferences/UserPreferencesExtensions.kt
@@ -13,8 +13,11 @@ fun UserPreferences.userAgent(application: Application): String =
         // WebSettings default identifies us as WebView and as WebView Google is preventing us to login to its services.
         // Clearly we don't want that so we just modify default user agent by removing the WebView specific parts.
         // That should make us look like Chrome, which we are really.
-        1 -> "Mozilla/5.0 (Linux; Android ${Build.VERSION.RELEASE})" +
-                WebSettings.getDefaultUserAgent(application).substringAfter(")")
+         1 -> {
+            var userAgent = Regex(" Build/.+; wv").replace(WebSettings.getDefaultUserAgent(application),"")
+            userAgent = Regex("Version/.+? ").replace(userAgent,"")
+            userAgent
+        }
         2 -> WINDOWS_DESKTOP_USER_AGENT
         3 -> LINUX_DESKTOP_USER_AGENT
         4 -> MACOS_DESKTOP_USER_AGENT
@@ -23,5 +26,7 @@ fun UserPreferences.userAgent(application: Application): String =
         7 -> System.getProperty("http.agent") ?: " "
         8 -> WebSettings.getDefaultUserAgent(application)
         9 -> userAgentString.takeIf(String::isNotEmpty) ?: " "
+        10 -> "Mozilla/5.0 (Linux; Android ${Build.VERSION.RELEASE})" +
+            WebSettings.getDefaultUserAgent(application).substringAfter(")")
         else -> throw UnsupportedOperationException("Unknown userAgentChoice: $choice")
     }

--- a/app/src/main/java/acr/browser/lightning/settings/preferences/UserPreferencesExtensions.kt
+++ b/app/src/main/java/acr/browser/lightning/settings/preferences/UserPreferencesExtensions.kt
@@ -12,11 +12,8 @@ fun UserPreferences.userAgent(application: Application): String =
         // WebSettings default identifies us as WebView and as WebView Google is preventing us to login to its services.
         // Clearly we don't want that so we just modify default user agent by removing the WebView specific parts.
         // That should make us look like Chrome, which we are really.
-        1 -> {
-            var userAgent = Regex(" Build/.+; wv").replace(WebSettings.getDefaultUserAgent(application),"")
-            userAgent = Regex("Version/.+? ").replace(userAgent,"")
-            userAgent
-        }
+        1 -> "Mozilla/5.0 (Linux; Android ${Build.VERSION.RELEASE})" +
+                WebSettings.getDefaultUserAgent(application).substringAfter(")")
         2 -> WINDOWS_DESKTOP_USER_AGENT
         3 -> LINUX_DESKTOP_USER_AGENT
         4 -> MACOS_DESKTOP_USER_AGENT

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -10,6 +10,7 @@
         <item>@string/agent_system</item>
         <item>@string/agent_web_view</item>
         <item>@string/agent_custom</item>
+        <item>@string/agent_hide_device</item>
     </string-array>
 
     <string-array name="download_folder">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -73,6 +73,7 @@
     <string name="agent_system">System</string>
     <string name="agent_web_view">WebView</string>
     <string name="agent_windows_desktop">Windows (Desktop)</string>
+    <string name="agent_hide_device">Hide device</string>
 
     <string name="title_search_engine">Search engine</string>
     <string name="action_ok">OK</string>


### PR DESCRIPTION
fix #275
This changes the user agent so it doesn't contain the device name; see linked issue for details.

@Slion & @jamal2362 
Do you want to keep the hardcoded engine version in Windows and Android user agents (`Chrome/88.0.4324.182`)?
I think they could be replaced with the actual version available on the device.