### PR TITLE
Put device WebView version in Windows and Android user agents

### DIFF
--- a/app/src/main/java/acr/browser/lightning/constant/Constants.kt
+++ b/app/src/main/java/acr/browser/lightning/constant/Constants.kt
@@ -6,10 +6,10 @@
 package acr.browser.lightning.constant
 
 // Hardcoded user agents
-const val WINDOWS_DESKTOP_USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.182 Safari/537.36"
+const val WINDOWS_DESKTOP_USER_AGENT_PREFIX = "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"
 const val LINUX_DESKTOP_USER_AGENT = "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:85.0) Gecko/20100101 Firefox/85.0"
 const val MACOS_DESKTOP_USER_AGENT = "Mozilla/5.0 (Macintosh; Intel Mac OS X 11_2_1) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.2 Safari/605.1.15"
-const val ANDROID_MOBILE_USER_AGENT = "Mozilla/5.0 (Linux; Android 11; Pixel 5 Build/RQ1A.210205.004; wv) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.152 Mobile Safari/537.36"
+const val ANDROID_MOBILE_USER_AGENT_PREFIX = "Mozilla/5.0 (Linux; Android 11; Pixel 5 Build/RQ1A.210205.004; wv)"
 const val IOS_MOBILE_USER_AGENT = "Mozilla/5.0 (iPhone; CPU iPhone OS 14_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0 Mobile/15E148 Safari/604.1"
 
 // URL Schemes

--- a/app/src/main/java/acr/browser/lightning/settings/preferences/UserPreferencesExtensions.kt
+++ b/app/src/main/java/acr/browser/lightning/settings/preferences/UserPreferencesExtensions.kt
@@ -13,20 +13,23 @@ fun UserPreferences.userAgent(application: Application): String =
         // WebSettings default identifies us as WebView and as WebView Google is preventing us to login to its services.
         // Clearly we don't want that so we just modify default user agent by removing the WebView specific parts.
         // That should make us look like Chrome, which we are really.
-         1 -> {
+        1 -> {
             var userAgent = Regex(" Build/.+; wv").replace(WebSettings.getDefaultUserAgent(application),"")
             userAgent = Regex("Version/.+? ").replace(userAgent,"")
             userAgent
         }
-        2 -> WINDOWS_DESKTOP_USER_AGENT
+        2 -> WINDOWS_DESKTOP_USER_AGENT_PREFIX + webViewEngineVersion(application)
         3 -> LINUX_DESKTOP_USER_AGENT
         4 -> MACOS_DESKTOP_USER_AGENT
-        5 -> ANDROID_MOBILE_USER_AGENT
+        5 -> ANDROID_MOBILE_USER_AGENT_PREFIX + webViewEngineVersion(application)
         6 -> IOS_MOBILE_USER_AGENT
         7 -> System.getProperty("http.agent") ?: " "
         8 -> WebSettings.getDefaultUserAgent(application)
         9 -> userAgentString.takeIf(String::isNotEmpty) ?: " "
         10 -> "Mozilla/5.0 (Linux; Android ${Build.VERSION.RELEASE})" +
-            WebSettings.getDefaultUserAgent(application).substringAfter(")")
+                webViewEngineVersion(application)
         else -> throw UnsupportedOperationException("Unknown userAgentChoice: $choice")
     }
+
+fun webViewEngineVersion(application: Application) =
+        WebSettings.getDefaultUserAgent(application).substringAfter(")")

--- a/app/src/main/java/acr/browser/lightning/view/LightningView.kt
+++ b/app/src/main/java/acr/browser/lightning/view/LightningView.kt
@@ -24,6 +24,7 @@ import acr.browser.lightning.network.NetworkConnectivityModel
 import acr.browser.lightning.settings.preferences.UserPreferences
 import acr.browser.lightning.settings.preferences.userAgent
 import acr.browser.lightning.settings.fragment.DisplaySettingsFragment.Companion.MIN_BROWSER_TEXT_SIZE
+import acr.browser.lightning.settings.preferences.webViewEngineVersion
 import acr.browser.lightning.ssl.SslState
 import acr.browser.lightning.utils.*
 import android.annotation.SuppressLint
@@ -165,7 +166,7 @@ class LightningView(
             field = aDesktopMode
             // Set our user agent accordingly
             if (aDesktopMode) {
-                webView?.settings?.userAgentString = WINDOWS_DESKTOP_USER_AGENT
+                webView?.settings?.userAgentString = WINDOWS_DESKTOP_USER_AGENT_PREFIX + webViewEngineVersion(activity.application)
             } else {
                 setUserAgentForPreference(userPreferences)
             }


### PR DESCRIPTION
Follow-up from #280

> I like the idea of using the actual Chrome version, it's easily accessible from the WebView as seen in our About settings page. Just maybe put it in other change.

This changes Windows and Android user agents from claiming we use WebView 88.0.4324.152 to the actual version.
Or should this rather be additional user agents to choose from?