### PR TITLE
Remove 'Mobile' and 'Version' from user agents

### DIFF
--- a/app/src/main/java/acr/browser/lightning/settings/preferences/UserPreferencesExtensions.kt
+++ b/app/src/main/java/acr/browser/lightning/settings/preferences/UserPreferencesExtensions.kt
@@ -18,7 +18,7 @@ fun UserPreferences.userAgent(application: Application): String =
             userAgent = Regex("Version/.+? ").replace(userAgent,"")
             userAgent
         }
-        2 -> WINDOWS_DESKTOP_USER_AGENT_PREFIX + webViewEngineVersion(application)
+        2 -> WINDOWS_DESKTOP_USER_AGENT_PREFIX + webViewEngineVersionDesktop(application)
         3 -> LINUX_DESKTOP_USER_AGENT
         4 -> MACOS_DESKTOP_USER_AGENT
         5 -> ANDROID_MOBILE_USER_AGENT_PREFIX + webViewEngineVersion(application)
@@ -33,3 +33,6 @@ fun UserPreferences.userAgent(application: Application): String =
 
 fun webViewEngineVersion(application: Application) =
         WebSettings.getDefaultUserAgent(application).substringAfter(")")
+
+fun webViewEngineVersionDesktop(application: Application) =
+        webViewEngineVersion(application).replace(" Mobile ", " ")

--- a/app/src/main/java/acr/browser/lightning/settings/preferences/UserPreferencesExtensions.kt
+++ b/app/src/main/java/acr/browser/lightning/settings/preferences/UserPreferencesExtensions.kt
@@ -32,7 +32,7 @@ fun UserPreferences.userAgent(application: Application): String =
     }
 
 fun webViewEngineVersion(application: Application) =
-        WebSettings.getDefaultUserAgent(application).substringAfter(")")
+        WebSettings.getDefaultUserAgent(application).substringAfter(")").replace("Version/.+? ".toRegex(), "")
 
 fun webViewEngineVersionDesktop(application: Application) =
         webViewEngineVersion(application).replace(" Mobile ", " ")

--- a/app/src/main/java/acr/browser/lightning/view/LightningView.kt
+++ b/app/src/main/java/acr/browser/lightning/view/LightningView.kt
@@ -24,7 +24,7 @@ import acr.browser.lightning.network.NetworkConnectivityModel
 import acr.browser.lightning.settings.preferences.UserPreferences
 import acr.browser.lightning.settings.preferences.userAgent
 import acr.browser.lightning.settings.fragment.DisplaySettingsFragment.Companion.MIN_BROWSER_TEXT_SIZE
-import acr.browser.lightning.settings.preferences.webViewEngineVersion
+import acr.browser.lightning.settings.preferences.webViewEngineVersionDesktop
 import acr.browser.lightning.ssl.SslState
 import acr.browser.lightning.utils.*
 import android.annotation.SuppressLint
@@ -166,7 +166,7 @@ class LightningView(
             field = aDesktopMode
             // Set our user agent accordingly
             if (aDesktopMode) {
-                webView?.settings?.userAgentString = WINDOWS_DESKTOP_USER_AGENT_PREFIX + webViewEngineVersion(activity.application)
+                webView?.settings?.userAgentString = WINDOWS_DESKTOP_USER_AGENT_PREFIX + webViewEngineVersionDesktop(activity.application)
             } else {
                 setUserAgentForPreference(userPreferences)
             }


### PR DESCRIPTION
WebView user agent contains the word 'Mobile' where the desktop agent should have nothing.
I forgot to remove this in the previous PR #283.

Mobile example (hide device)
"Mozilla/5.0 (Linux; Android 9) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/95.0.4638.78 **Mobile** Safari/537.36"

Desktop example (actiual desktop browser)
"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.113 Safari/537.36"

Here I also noticed that I hadn't removed the 'Version' in the Hide Device user agent.
This is fixed in this PR as well.
(I feel a bit stupid for requiring 3 PRs for such simple changes, but at least I noticed...)