### PR TITLE
Fix potential crash on startup on antiquated devices

### DIFF
--- a/app/src/main/java/acr/browser/lightning/browser/activity/BrowserActivity.kt
+++ b/app/src/main/java/acr/browser/lightning/browser/activity/BrowserActivity.kt
@@ -3850,6 +3850,7 @@ abstract class BrowserActivity : ThemedBrowserActivity(), BrowserView, UIControl
 
             }
         }
+        if (tabsManager.currentTab == null) return false
         return super.dispatchTouchEvent(anEvent)
     }
 


### PR DESCRIPTION
fixes #285

The return value is whether the touch event has been handled. In my understanding true or false is irrelevant at this point.