### PR TITLE
Fix "touch-transparent" bookmarks drawer text

### DIFF
--- a/app/src/main/java/acr/browser/lightning/browser/bookmarks/BookmarksDrawerView.kt
+++ b/app/src/main/java/acr/browser/lightning/browser/bookmarks/BookmarksDrawerView.kt
@@ -43,7 +43,8 @@ class BookmarksDrawerView @JvmOverloads constructor(
     @Inject internal lateinit var bookmarksDialogBuilder: LightningDialogBuilder
     @Inject internal lateinit var faviconModel: FaviconModel
     @Inject @field:DatabaseScheduler internal lateinit var databaseScheduler: Scheduler
-    @Inject @field:NetworkScheduler internal lateinit var networkScheduler: Scheduler
+    @Inject @field:NetworkScheduler inter        iBinding.textTitle.setOnClickListener { }
+nal lateinit var networkScheduler: Scheduler
     @Inject @field:MainScheduler internal lateinit var mainScheduler: Scheduler
     @Inject
     lateinit var iUserPreferences: UserPreferences
@@ -77,6 +78,8 @@ class BookmarksDrawerView @JvmOverloads constructor(
                 iBinding.listBookmarks.layoutManager?.scrollToPosition(scrollIndex)
             }
         }
+
+        iBinding.textTitle.setOnClickListener { }
 
         iAdapter = BookmarksAdapter(
                 context,

--- a/app/src/main/java/acr/browser/lightning/browser/bookmarks/BookmarksDrawerView.kt
+++ b/app/src/main/java/acr/browser/lightning/browser/bookmarks/BookmarksDrawerView.kt
@@ -43,8 +43,7 @@ class BookmarksDrawerView @JvmOverloads constructor(
     @Inject internal lateinit var bookmarksDialogBuilder: LightningDialogBuilder
     @Inject internal lateinit var faviconModel: FaviconModel
     @Inject @field:DatabaseScheduler internal lateinit var databaseScheduler: Scheduler
-    @Inject @field:NetworkScheduler inter        iBinding.textTitle.setOnClickListener { }
-nal lateinit var networkScheduler: Scheduler
+    @Inject @field:NetworkScheduler internal lateinit var networkScheduler: Scheduler
     @Inject @field:MainScheduler internal lateinit var mainScheduler: Scheduler
     @Inject
     lateinit var iUserPreferences: UserPreferences


### PR DESCRIPTION
Touching the "Bookmarks" text in bookmarks drawer does not handle any touch event.
The behavior is as if the element hidden by bookmarks drawer is touched (link in page, open popup menu, enter url, reload page,...)

The onClickListener on the text, which is added in this PR, intercepts the touch event, so nothing happens.