### PR TITLE
Improve content control UI

### DIFF
--- a/app/src/main/java/acr/browser/lightning/adblock/AbpListUpdater.kt
+++ b/app/src/main/java/acr/browser/lightning/adblock/AbpListUpdater.kt
@@ -16,12 +16,16 @@
 
 package acr.browser.lightning.adblock
 
+import acr.browser.lightning.R
 import acr.browser.lightning.adblock.parser.HostsFileParser
+import acr.browser.lightning.extensions.toast
 import acr.browser.lightning.log.Logger
 import acr.browser.lightning.settings.preferences.UserPreferences
 import android.content.Context
 import android.net.ConnectivityManager
 import android.net.Uri
+import android.os.Handler
+import android.os.Looper
 import jp.hazuki.yuzubrowser.adblock.filter.abp.*
 import jp.hazuki.yuzubrowser.adblock.filter.unified.FILTER_DIR
 import jp.hazuki.yuzubrowser.adblock.filter.unified.StartEndFilter
@@ -146,6 +150,9 @@ class AbpListUpdater @Inject constructor(val context: Context) {
             }
         } catch (e: IOException) {
             e.printStackTrace()
+            Handler(Looper.getMainLooper()).post {
+                context.toast(context.getString(R.string.blocklist_update_error, entity.title))
+            }
         }
         return false
     }

--- a/app/src/main/java/acr/browser/lightning/settings/fragment/AdBlockSettingsFragment.kt
+++ b/app/src/main/java/acr/browser/lightning/settings/fragment/AdBlockSettingsFragment.kt
@@ -316,13 +316,9 @@ class AdBlockSettingsFragment : AbstractSettingsFragment() {
             entity.enabled = enabled.isChecked
 
             entity.title = title.text.toString()
-            val newId = abpDao.update(entity) // new id if new entity was added, otherwise newId == entity.entityId
-
-            // set new id for newly added list
-            if (entity.entityId == 0) {
-                entity.entityId = newId
+            if (entity.entityId == 0) // id == 0 if new entity was added, we want to update it immediately
                 needsUpdate = true
-            }
+            val newId = abpDao.update(entity)
 
             // check for update (necessary to have correct id!)
             if ((entity.url.startsWith("http") && enabled.isChecked && !wasEnabled) || needsUpdate)

--- a/app/src/main/java/acr/browser/lightning/settings/fragment/AdBlockSettingsFragment.kt
+++ b/app/src/main/java/acr/browser/lightning/settings/fragment/AdBlockSettingsFragment.kt
@@ -181,6 +181,10 @@ class AdBlockSettingsFragment : AbstractSettingsFragment() {
     private fun updateEntity(abpEntity: AbpEntity?, forceUpdate: Boolean) {
         GlobalScope.launch(Dispatchers.IO) {
             ++updatesRunning
+            activity?.runOnUiThread {
+                if (abpEntity != null)
+                    entityPrefs[abpEntity.entityId]?.summary = resources.getString(R.string.blocklist_updating)
+            }
             val updated = if (abpEntity == null) abpListUpdater.updateAll(forceUpdate) else abpListUpdater.updateAbpEntity(abpEntity, forceUpdate)
 
             // delete temporary file

--- a/app/src/main/java/acr/browser/lightning/settings/fragment/AdBlockSettingsFragment.kt
+++ b/app/src/main/java/acr/browser/lightning/settings/fragment/AdBlockSettingsFragment.kt
@@ -285,7 +285,7 @@ class AdBlockSettingsFragment : AbstractSettingsFragment() {
                     .setPositiveButton(R.string.action_delete) { _, _ ->
                         abpDao.delete(entity)
                         dialog?.dismiss()
-                        preferenceScreen.removePreference(entityPrefs[entity.entityId])
+                        filtersCategory.removePreference(entityPrefs[entity.entityId])
                         reloadBlockLists()
                     }
                     .setTitle(resources.getString(R.string.blocklist_remove_confirm, entity.title))

--- a/app/src/main/java/acr/browser/lightning/settings/fragment/AdBlockSettingsFragment.kt
+++ b/app/src/main/java/acr/browser/lightning/settings/fragment/AdBlockSettingsFragment.kt
@@ -154,7 +154,7 @@ class AdBlockSettingsFragment : AbstractSettingsFragment() {
             newList.dependency = getString(R.string.pref_key_content_control)
 
             // list of blocklists/entities
-            for (entity in abpDao.getAll()) {
+            for (entity in abpDao.getAll().sortedBy { it.title?.lowercase() }) {
                 val entityPref = Preference(context)
 //                val pref = SwitchPreferenceCompat(context) // not working... is there a way to separate clicks on text and switch?
 //                pref.isChecked = entity.enabled

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -184,6 +184,7 @@
     <string name="blocklist_update_description">Updates will be done with the chosen frequency, unless the filters file specifies a longer interval</string>
     <string name="blocklist_update_now">Update lists now</string>
     <string name="blocklist_last_update">Last update: %s</string>
+    <string name="blocklist_updating">Updating…</string>
     <string name="add_blocklist">Add filters file</string>
     <string name="add_blocklist_hint">You can choose hosts lists or any list compatible with AdBlockPlus rules</string>
     <string name="enable_blocklist">Enable this list</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -185,6 +185,7 @@
     <string name="blocklist_update_now">Update lists now</string>
     <string name="blocklist_last_update">Last update: %s</string>
     <string name="blocklist_updating">Updating…</string>
+    <string name="blocklist_update_error">Error while updating filters list %s</string>
     <string name="add_blocklist">Add filters file</string>
     <string name="add_blocklist_hint">You can choose hosts lists or any list compatible with AdBlockPlus rules</string>
     <string name="enable_blocklist">Enable this list</string>


### PR DESCRIPTION
This PR improves inconveniences and minor bugs with content control:
* filter lists are now ordered alphabetically instead of by id
* when a filter list is added, list of filter lists is reloaded to show correct oder
* newly added filter lists are now downloaded immediately
* when a filter list is currently updating, the preference summary shows "Updating..."
* if an error occurs while a filter list is updated, a toast message is shown
* removed filter lists are now again removed from preferences without needing to leave and re-enter the screen