### PR TITLE
Add user agent to AbpListUpdater

### DIFF
--- a/app/src/main/java/acr/browser/lightning/adblock/AbpListUpdater.kt
+++ b/app/src/main/java/acr/browser/lightning/adblock/AbpListUpdater.kt
@@ -21,6 +21,8 @@ import acr.browser.lightning.adblock.parser.HostsFileParser
 import acr.browser.lightning.extensions.toast
 import acr.browser.lightning.log.Logger
 import acr.browser.lightning.settings.preferences.UserPreferences
+import acr.browser.lightning.settings.preferences.userAgent
+import android.app.Application
 import android.content.Context
 import android.net.ConnectivityManager
 import android.net.Uri
@@ -112,6 +114,7 @@ class AbpListUpdater @Inject constructor(val context: Context) {
         val request = try {
             Request.Builder()
                 .url(entity.url)
+                .header("User-Agent", userPreferences.userAgent(context.applicationContext as Application))
                 .get()
         } catch (e: IllegalArgumentException) {
             return false


### PR DESCRIPTION
For downloading filters lists, default okhttp user agent is used (currently `okhttp/4.9.1`).
I think we should use the user's choice for this as well, though I am not sure whether there are any "real" benefits of this proposed change.