### PR TITLE
Content control updates

### DIFF
--- a/app/src/main/java/acr/browser/lightning/settings/fragment/AdBlockSettingsFragment.kt
+++ b/app/src/main/java/acr/browser/lightning/settings/fragment/AdBlockSettingsFragment.kt
@@ -9,6 +9,7 @@ import acr.browser.lightning.extensions.toast
 import acr.browser.lightning.extensions.withSingleChoiceItems
 import acr.browser.lightning.settings.preferences.UserPreferences
 import android.app.Activity
+import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
@@ -36,6 +37,7 @@ import java.io.IOException
 import java.text.DateFormat
 import java.util.*
 import javax.inject.Inject
+import androidx.preference.PreferenceViewHolder
 
 /**
  * Settings for the ad block mechanic.
@@ -48,7 +50,7 @@ class AdBlockSettingsFragment : AbstractSettingsFragment() {
     @Inject internal lateinit var abpBlocker: AbpBlocker
 
     private lateinit var abpDao: AbpDao
-    private val entityPrefs = mutableMapOf<Int, SwitchPreferenceCompat>()
+    private val entityPrefs = mutableMapOf<Int, FilterListSwitchPreference>()
 
     // if blocklist changed, they need to be reloaded, but this should happen only once
     //  if reloadLists is true, list reload will be launched onDestroy
@@ -84,7 +86,10 @@ class AdBlockSettingsFragment : AbstractSettingsFragment() {
             onCheckChange = {
                 userPreferences.adBlockEnabled = it
                 // update enabled lists when enabling blocker
-                if (it) updateEntity(null, false)
+                if (it) {
+                    updateFilterList(null, false)
+                    reloadLists = true
+                }
             }
         )
 
@@ -129,7 +134,7 @@ class AdBlockSettingsFragment : AbstractSettingsFragment() {
                         }
                         setPositiveButton(resources.getString(R.string.action_ok), null)
                         setNeutralButton(R.string.blocklist_update_now) {_,_ ->
-                            updateEntity(null, true)
+                            updateFilterList(null, true)
                         }
                     }?.resizeAndShow()
                 }
@@ -162,15 +167,7 @@ class AdBlockSettingsFragment : AbstractSettingsFragment() {
 
         // list of blocklists/entities
         for (entity in abpDao.getAll().sortedBy { it.title?.lowercase() }) {
-            val entityPref = SwitchPreferenceCompat(context)
-            entityPref.isChecked = entity.enabled
-            entityPref.title = entity.title
-            //entityPref.icon = requireContext().drawable(R.drawable.ic_import_export)
-            entityPref.onPreferenceClickListener = Preference.OnPreferenceClickListener {
-                (it as SwitchPreferenceCompat).isChecked = entity.enabled // avoid flipping the switch on click
-                showBlockList(entity)
-                true
-            }
+            val entityPref = FilterListSwitchPreference(context, entity)
             entityPrefs[entity.entityId] = entityPref
             updateSummary(entity)
             filtersCategory.addPreference(entityPrefs[entity.entityId])
@@ -182,11 +179,18 @@ class AdBlockSettingsFragment : AbstractSettingsFragment() {
     private fun updateSummary(entity: AbpEntity) {
         if (entity.lastLocalUpdate > 0)
             entityPrefs[entity.entityId]?.summary = resources.getString(R.string.blocklist_last_update, DateFormat.getDateTimeInstance().format(Date(entity.lastLocalUpdate)))
+        else
+            entityPrefs[entity.entityId]?.summary = ""
     }
 
-    // update entity and adjust displayed last update time
-    private fun updateEntity(abpEntity: AbpEntity?, forceUpdate: Boolean) {
+    // update filter list and adjust displayed last update time
+    //  update all lists if no entity provided
+    private fun updateFilterList(abpEntity: AbpEntity?, forceUpdate: Boolean) {
         GlobalScope.launch(Dispatchers.IO) {
+            // do nothing if update not required
+            if (!forceUpdate && abpEntity != null && !abpListUpdater.needsUpdate(abpEntity))
+                return@launch
+
             ++updatesRunning
             activity?.runOnUiThread {
                 if (abpEntity != null)
@@ -199,14 +203,13 @@ class AdBlockSettingsFragment : AbstractSettingsFragment() {
             //  so it could happen that lists get mixed up via an old temporary blocklist file
             activity?.externalCacheDir?.let { File(it, BLOCK_LIST_FILE).delete() }
 
-            if (updated) {
+            if (updated)
                 reloadBlockLists()
 
-                // update the "last updated" times
-                activity?.runOnUiThread {
-                    for (entity in abpDao.getAll())
-                        updateSummary(entity)
-                }
+            // update the "last updated" times
+            activity?.runOnUiThread {
+                for (entity in abpDao.getAll())
+                    updateSummary(entity)
             }
             --updatesRunning
         }
@@ -232,6 +235,7 @@ class AdBlockSettingsFragment : AbstractSettingsFragment() {
         linearLayout.addView(title)
 
         var needsUpdate = false
+        val oldUrl = entity.url
 
         // field for choosing file or url
         when {
@@ -278,12 +282,6 @@ class AdBlockSettingsFragment : AbstractSettingsFragment() {
             }
         }
 
-        // enabled switch
-        val enabled = SwitchCompat(requireContext())
-        enabled.text = resources.getString(R.string.enable_blocklist)
-        enabled.isChecked = entity.enabled
-        linearLayout.addView(enabled)
-
         // delete button
         // don't show for internal list or when creating a new entity
         if (entity.entityId != 0) {
@@ -312,20 +310,23 @@ class AdBlockSettingsFragment : AbstractSettingsFragment() {
         builder.setView(linearLayout)
         builder.setNegativeButton(R.string.action_cancel, null)
         builder.setPositiveButton(R.string.action_ok) { _,_ ->
-            val wasEnabled = entity.enabled
-            entity.enabled = enabled.isChecked
-            entityPrefs[entity.entityId]?.isChecked = entity.enabled
 
             entity.title = title.text.toString()
+
+            // make sure list is reloaded if url changed
+            if (oldUrl != entity.url) {
+                entity.lastLocalUpdate = 0
+                entity.lastModified = null
+                needsUpdate = true
+            }
+
             if (entity.entityId == 0) // id == 0 if new entity was added, we want to update it immediately
                 needsUpdate = true
             val newId = abpDao.update(entity)
 
-            // check for update (necessary to have correct id!)
-            if ((entity.url.startsWith("http") && enabled.isChecked && !wasEnabled) || needsUpdate)
-                updateEntity(entity, needsUpdate)
-            if (enabled.isChecked != wasEnabled)
-                reloadBlockLists()
+            // check for update (after abpDao.update!)
+            if (needsUpdate)
+                updateFilterList(entity, needsUpdate)
 
             if (entityPrefs[newId] == null) // not in entityPrefs if new
                 loadFilterLists() // load lists again, to get alphabetical order
@@ -412,6 +413,38 @@ override fun onDestroy() {
             }
         }
         super.onActivityResult(requestCode, resultCode, data)
+    }
+
+    // class necessary to allow separate onClickListener for the switch
+    private inner class FilterListSwitchPreference(context : Context?, val entity: AbpEntity) : SwitchPreferenceCompat(context) {
+
+        override fun onBindViewHolder(holder: PreferenceViewHolder?) {
+            super.onBindViewHolder(holder)
+            val switch: SwitchCompat? = holder?.itemView?.findViewById(R.id.filter_list_switch_widget)
+            switch?.isChecked = entity.enabled
+            switch?.setOnClickListener {
+                isChecked = (it as SwitchCompat).isChecked
+                entity.enabled = isChecked
+                abpDao.update(entity)
+                if (isChecked)
+                    updateFilterList(entity, false) // check for update, entity may have been disabled for a longer time
+                reloadBlockLists()
+            }
+            onPreferenceClickListener = OnPreferenceClickListener {
+                (it as FilterListSwitchPreference).isChecked = entity.enabled // avoid flipping the switch on click
+                showBlockList(entity)
+                true
+            }
+        }
+
+        // layout resource must be set before onBindViewHolder
+        // title and isChecked can't be changed in onBindViewHolder, so also set it now
+        override fun onAttached() {
+            super.onAttached()
+            title = entity.title
+            isChecked = entity.enabled
+            widgetLayoutResource = R.layout.filter_list_preference_widget
+        }
     }
 
     companion object {

--- a/app/src/main/res/layout/filter_list_preference_widget.xml
+++ b/app/src/main/res/layout/filter_list_preference_widget.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+android:layout_width="wrap_content"
+android:layout_height="wrap_content"
+android:orientation="vertical">
+
+<androidx.appcompat.widget.SwitchCompat
+    android:id="@+id/filter_list_switch_widget"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"/>
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -186,6 +186,7 @@
     <string name="blocklist_last_update">Last update: %s</string>
     <string name="blocklist_updating">Updating…</string>
     <string name="blocklist_update_error">Error while updating filters list %s</string>
+    <string name="blocklist_update_error_404">Error while updating filters list %s: url not found</string>
     <string name="add_blocklist">Add filters file</string>
     <string name="add_blocklist_hint">You can choose hosts lists or any list compatible with AdBlockPlus rules</string>
     <string name="enable_blocklist">Enable this list</string>


### PR DESCRIPTION
Fixes #224 in a better way, and some smaller things:

* settings: add preference class that allows switching the list without opening the dialog
* settings: rename updateEntity to updateFilterList (to be more clear)
* settings: update filter lists only if necessary (on enable list)
* settings: reload list if URL changed (did not happen previously)
* updater: handle error 404 (looked like a successful update)
* blocker: load filter lists only if blocker actually enabled (blocker is always loaded, even if not used, since migration to hilt)