### PR TITLE
Store user agent choice as string to allow re-ordering

### DIFF
--- a/app/src/main/java/acr/browser/lightning/settings/fragment/GeneralSettingsFragment.kt
+++ b/app/src/main/java/acr/browser/lightning/settings/fragment/GeneralSettingsFragment.kt
@@ -327,36 +327,20 @@ class GeneralSettingsFragment : AbstractSettingsFragment() {
         }
     }
 
-    private fun userAgentSummary() = choiceToUserAgent(userPreferences.userAgentChoice) + activity?.application?.let { ":\n" + userPreferences.userAgent(it) }
-
-    private fun choiceToUserAgent(agent: String) = when (agent) {
-        USER_AGENT_DEFAULT -> resources.getString(R.string.agent_default)
-        USER_AGENT_WINDOWS_DESKTOP -> resources.getString(R.string.agent_windows_desktop)
-        USER_AGENT_LINUX_DESKTOP -> resources.getString(R.string.agent_linux_desktop)
-        USER_AGENT_MACOS_DESKTOP -> resources.getString(R.string.agent_macos_desktop)
-        USER_AGENT_ANDROID_MOBILE -> resources.getString(R.string.agent_android_mobile)
-        USER_AGENT_IOS_MOBILE -> resources.getString(R.string.agent_ios_mobile)
-        USER_AGENT_SYSTEM -> resources.getString(R.string.agent_system)
-        USER_AGENT_WEB_VIEW -> resources.getString(R.string.agent_web_view)
-        USER_AGENT_CUSTOM -> resources.getString(R.string.agent_custom)
-        USER_AGENT_HIDE_DEVICE -> resources.getString(R.string.agent_hide_device)
-        else -> resources.getString(R.string.agent_default)
-    }
-
-    private fun String.toAgentIndex(): Int {
-        val a = USER_AGENTS_ORDERED
-        val index = a.indexOf(this)
-        return if (index == -1) 0 else index
-    }
+    private fun userAgentSummary() =
+        resources.getString(USER_AGENTS_ORDERED[userPreferences.userAgentChoice] ?: R.string.agent_default) +
+                activity?.application?.let { ":\n" + userPreferences.userAgent(it) }
 
     private fun showUserAgentChooserDialog(summaryUpdater: SummaryUpdater) {
         activity?.let { activity ->
-            val userAgentChoices = USER_AGENTS_ORDERED//resources.getStringArray(R.array.user_agent)
+            val userAgentChoices = USER_AGENTS_ORDERED.keys.toTypedArray()
+            val currentAgentIndex = userAgentChoices.indexOf(userPreferences.userAgentChoice).
+                let {if (it == -1) 0 else it}
             BrowserDialog.showCustomDialog(activity as AppCompatActivity) {
                 setTitle(resources.getString(R.string.title_user_agent))
                 setSingleChoiceItems(
-                    userAgentChoices.map { choiceToUserAgent(it) }.toTypedArray(),
-                    userPreferences.userAgentChoice.toAgentIndex())
+                    USER_AGENTS_ORDERED.values.map { resources.getString(it) }.toTypedArray(),
+                    currentAgentIndex)
                 { _, which ->
                     userPreferences.userAgentChoice = userAgentChoices[which]
                     if (userAgentChoices[which] == USER_AGENT_CUSTOM)

--- a/app/src/main/java/acr/browser/lightning/settings/preferences/UserPreferences.kt
+++ b/app/src/main/java/acr/browser/lightning/settings/preferences/UserPreferences.kt
@@ -188,7 +188,7 @@ class UserPreferences @Inject constructor(
      *
      * @see UserPreferences.userAgent
      */
-    var userAgentChoice by preferences.stringPreference(USER_AGENT, USER_AGENT_DEFAULT)
+    var userAgentChoice by preferences.stringPreference(R.string.pref_key_user_agent, USER_AGENT_DEFAULT)
 
     /**
      * The custom user agent that should be used by the browser.
@@ -439,7 +439,6 @@ private const val LOCATION = "location"
 private const val SAVE_PASSWORDS = "passwords"
 private const val SEARCH = "search"
 private const val SEARCH_URL = "searchurl"
-private const val USER_AGENT = "userAgentChoice"
 private const val USER_AGENT_STRING = "userAgentString"
 private const val CLEAR_HISTORY_EXIT = "clearHistoryExit"
 private const val CLEAR_COOKIES_EXIT = "clearCookiesExit"

--- a/app/src/main/java/acr/browser/lightning/settings/preferences/UserPreferences.kt
+++ b/app/src/main/java/acr/browser/lightning/settings/preferences/UserPreferences.kt
@@ -188,7 +188,7 @@ class UserPreferences @Inject constructor(
      *
      * @see UserPreferences.userAgent
      */
-    var userAgentChoice by preferences.intPreference(USER_AGENT, 1)
+    var userAgentChoice by preferences.stringPreference(USER_AGENT, USER_AGENT_DEFAULT)
 
     /**
      * The custom user agent that should be used by the browser.
@@ -439,7 +439,7 @@ private const val LOCATION = "location"
 private const val SAVE_PASSWORDS = "passwords"
 private const val SEARCH = "search"
 private const val SEARCH_URL = "searchurl"
-private const val USER_AGENT = "agentchoose"
+private const val USER_AGENT = "userAgentChoice"
 private const val USER_AGENT_STRING = "userAgentString"
 private const val CLEAR_HISTORY_EXIT = "clearHistoryExit"
 private const val CLEAR_COOKIES_EXIT = "clearCookiesExit"

--- a/app/src/main/java/acr/browser/lightning/settings/preferences/UserPreferencesExtensions.kt
+++ b/app/src/main/java/acr/browser/lightning/settings/preferences/UserPreferencesExtensions.kt
@@ -1,5 +1,6 @@
 package acr.browser.lightning.settings.preferences
 
+import acr.browser.lightning.R
 import acr.browser.lightning.constant.*
 import android.app.Application
 import android.os.Build
@@ -37,26 +38,28 @@ fun webViewEngineVersion(application: Application) =
 fun webViewEngineVersionDesktop(application: Application) =
         webViewEngineVersion(application).replace(" Mobile ", " ")
 
-    const val USER_AGENT_DEFAULT = "agent_default"
-    const val USER_AGENT_HIDE_DEVICE = "agent_hide_device"
-    const val USER_AGENT_WINDOWS_DESKTOP = "agent_windows_desktop"
-    const val USER_AGENT_LINUX_DESKTOP = "agent_linux_desktop"
-    const val USER_AGENT_MACOS_DESKTOP = "agent_macos_desktop"
-    const val USER_AGENT_ANDROID_MOBILE = "agent_android_mobile"
-    const val USER_AGENT_IOS_MOBILE = "agent_ios_mobile"
-    const val USER_AGENT_SYSTEM = "agent_system"
-    const val USER_AGENT_WEB_VIEW = "agent_web_view"
-    const val USER_AGENT_CUSTOM = "agent_custom"
+const val USER_AGENT_DEFAULT = "agent_default"
+const val USER_AGENT_HIDE_DEVICE = "agent_hide_device"
+const val USER_AGENT_WINDOWS_DESKTOP = "agent_windows_desktop"
+const val USER_AGENT_LINUX_DESKTOP = "agent_linux_desktop"
+const val USER_AGENT_MACOS_DESKTOP = "agent_macos_desktop"
+const val USER_AGENT_ANDROID_MOBILE = "agent_android_mobile"
+const val USER_AGENT_IOS_MOBILE = "agent_ios_mobile"
+const val USER_AGENT_SYSTEM = "agent_system"
+const val USER_AGENT_WEB_VIEW = "agent_web_view"
+const val USER_AGENT_CUSTOM = "agent_custom"
 
-    val USER_AGENTS_ORDERED = arrayOf(
-        USER_AGENT_DEFAULT,
-        USER_AGENT_ANDROID_MOBILE,
-        USER_AGENT_IOS_MOBILE,
-        USER_AGENT_SYSTEM,
-        USER_AGENT_WEB_VIEW,
-        USER_AGENT_CUSTOM,
-        USER_AGENT_HIDE_DEVICE,
-        USER_AGENT_WINDOWS_DESKTOP,
-        USER_AGENT_LINUX_DESKTOP,
-        USER_AGENT_MACOS_DESKTOP,
-    )
+// use LinkedHashMap because it keeps insertion order
+//  in tests, order was also kept for Map. But this is not guaranteed
+val USER_AGENTS_ORDERED = linkedMapOf(
+    USER_AGENT_DEFAULT to R.string.agent_default,
+    USER_AGENT_HIDE_DEVICE to R.string.agent_hide_device,
+    USER_AGENT_WINDOWS_DESKTOP to R.string.agent_windows_desktop,
+    USER_AGENT_LINUX_DESKTOP to R.string.agent_linux_desktop,
+    USER_AGENT_MACOS_DESKTOP to R.string.agent_macos_desktop,
+    USER_AGENT_ANDROID_MOBILE to R.string.agent_android_mobile,
+    USER_AGENT_IOS_MOBILE to R.string.agent_ios_mobile,
+    USER_AGENT_SYSTEM to R.string.agent_system,
+    USER_AGENT_WEB_VIEW to R.string.agent_web_view,
+    USER_AGENT_CUSTOM to R.string.agent_custom,
+)

--- a/app/src/main/java/acr/browser/lightning/settings/preferences/UserPreferencesExtensions.kt
+++ b/app/src/main/java/acr/browser/lightning/settings/preferences/UserPreferencesExtensions.kt
@@ -13,20 +13,20 @@ fun UserPreferences.userAgent(application: Application): String =
         // WebSettings default identifies us as WebView and as WebView Google is preventing us to login to its services.
         // Clearly we don't want that so we just modify default user agent by removing the WebView specific parts.
         // That should make us look like Chrome, which we are really.
-        1 -> {
+        USER_AGENT_DEFAULT -> {
             var userAgent = Regex(" Build/.+; wv").replace(WebSettings.getDefaultUserAgent(application),"")
             userAgent = Regex("Version/.+? ").replace(userAgent,"")
             userAgent
         }
-        2 -> WINDOWS_DESKTOP_USER_AGENT_PREFIX + webViewEngineVersionDesktop(application)
-        3 -> LINUX_DESKTOP_USER_AGENT
-        4 -> MACOS_DESKTOP_USER_AGENT
-        5 -> ANDROID_MOBILE_USER_AGENT_PREFIX + webViewEngineVersion(application)
-        6 -> IOS_MOBILE_USER_AGENT
-        7 -> System.getProperty("http.agent") ?: " "
-        8 -> WebSettings.getDefaultUserAgent(application)
-        9 -> userAgentString.takeIf(String::isNotEmpty) ?: " "
-        10 -> "Mozilla/5.0 (Linux; Android ${Build.VERSION.RELEASE})" +
+        USER_AGENT_WINDOWS_DESKTOP -> WINDOWS_DESKTOP_USER_AGENT_PREFIX + webViewEngineVersionDesktop(application)
+        USER_AGENT_LINUX_DESKTOP -> LINUX_DESKTOP_USER_AGENT
+        USER_AGENT_MACOS_DESKTOP -> MACOS_DESKTOP_USER_AGENT
+        USER_AGENT_ANDROID_MOBILE -> ANDROID_MOBILE_USER_AGENT_PREFIX + webViewEngineVersion(application)
+        USER_AGENT_IOS_MOBILE -> IOS_MOBILE_USER_AGENT
+        USER_AGENT_SYSTEM -> System.getProperty("http.agent") ?: " "
+        USER_AGENT_WEB_VIEW -> WebSettings.getDefaultUserAgent(application)
+        USER_AGENT_CUSTOM -> userAgentString.takeIf(String::isNotEmpty) ?: " "
+        USER_AGENT_HIDE_DEVICE-> "Mozilla/5.0 (Linux; Android ${Build.VERSION.RELEASE})" +
                 webViewEngineVersion(application)
         else -> throw UnsupportedOperationException("Unknown userAgentChoice: $choice")
     }
@@ -36,3 +36,27 @@ fun webViewEngineVersion(application: Application) =
 
 fun webViewEngineVersionDesktop(application: Application) =
         webViewEngineVersion(application).replace(" Mobile ", " ")
+
+    const val USER_AGENT_DEFAULT = "agent_default"
+    const val USER_AGENT_HIDE_DEVICE = "agent_hide_device"
+    const val USER_AGENT_WINDOWS_DESKTOP = "agent_windows_desktop"
+    const val USER_AGENT_LINUX_DESKTOP = "agent_linux_desktop"
+    const val USER_AGENT_MACOS_DESKTOP = "agent_macos_desktop"
+    const val USER_AGENT_ANDROID_MOBILE = "agent_android_mobile"
+    const val USER_AGENT_IOS_MOBILE = "agent_ios_mobile"
+    const val USER_AGENT_SYSTEM = "agent_system"
+    const val USER_AGENT_WEB_VIEW = "agent_web_view"
+    const val USER_AGENT_CUSTOM = "agent_custom"
+
+    val USER_AGENTS_ORDERED = arrayOf(
+        USER_AGENT_DEFAULT,
+        USER_AGENT_ANDROID_MOBILE,
+        USER_AGENT_IOS_MOBILE,
+        USER_AGENT_SYSTEM,
+        USER_AGENT_WEB_VIEW,
+        USER_AGENT_CUSTOM,
+        USER_AGENT_HIDE_DEVICE,
+        USER_AGENT_WINDOWS_DESKTOP,
+        USER_AGENT_LINUX_DESKTOP,
+        USER_AGENT_MACOS_DESKTOP,
+    )

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -1,17 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string-array name="user_agent">
-        <item>@string/agent_default</item>
-        <item>@string/agent_windows_desktop</item>
-        <item>@string/agent_linux_desktop</item>
-        <item>@string/agent_macos_desktop</item>
-        <item>@string/agent_android_mobile</item>
-        <item>@string/agent_ios_mobile</item>
-        <item>@string/agent_system</item>
-        <item>@string/agent_web_view</item>
-        <item>@string/agent_custom</item>
-        <item>@string/agent_hide_device</item>
-    </string-array>
 
     <string-array name="download_folder">
         <item>@string/folder_default</item>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -34,6 +34,7 @@
     <string name="pref_key_pull_to_refresh">pref_key_pull_to_refresh</string>
     <string name="pref_key_tab_bar_vertical">pref_key_tab_bar_vertical</string>
     <string name="pref_key_toolbars_bottom">pref_key_toolbars_bottom</string>
+    <string name="pref_key_user_agent">pref_key_user_agent</string>
 
     <!-- On tab close -->
     <string name="pref_key_on_tab_close_show_snackbar">pref_key_on_tab_close_show_snackbar</string>


### PR DESCRIPTION
With this PR, user agent is stored as string instead of integer, which allows for simple re-ordering in the user agent list, and adding new ones at arbitrary positions.

The user agent will be reset to default, see also https://github.com/Slion/Fulguris/pull/283#discussion_r776730720

Initially I tried storing the array in arrays.xml, but that can't be read in UserPreferences.kt (required for default)