### PR TITLE
Replace deprecated ButterKnife with view binding

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -307,11 +307,6 @@ dependencies {
 
     compileOnly 'javax.annotation:jsr250-api:1.0'
 
-    // view binding
-    final def butterKnifeVersion = '10.2.1'
-    implementation "com.jakewharton:butterknife:$butterKnifeVersion"
-    kapt "com.jakewharton:butterknife-compiler:$butterKnifeVersion"
-
     // permissions
     implementation 'com.anthonycr.grant:permissions:1.1.2'
 

--- a/app/src/main/java/acr/browser/lightning/browser/activity/BrowserActivity.kt
+++ b/app/src/main/java/acr/browser/lightning/browser/activity/BrowserActivity.kt
@@ -95,7 +95,6 @@ import androidx.drawerlayout.widget.DrawerLayout
 import androidx.palette.graphics.Palette
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import butterknife.ButterKnife
 import com.android.volley.*
 import com.android.volley.toolbox.JsonObjectRequest
 import com.android.volley.toolbox.Volley
@@ -306,9 +305,6 @@ abstract class BrowserActivity : ThemedBrowserActivity(), BrowserView, UIControl
         iBinding.findInPageInclude.buttonBack.setOnClickListener(this)
         iBinding.findInPageInclude.buttonQuit.setOnClickListener(this)
 
-
-
-        ButterKnife.bind(this)
         queue = Volley.newRequestQueue(this)
         createMenuMain()
         createMenuWebPage()

--- a/app/src/main/java/acr/browser/lightning/reading/ReadingActivity.kt
+++ b/app/src/main/java/acr/browser/lightning/reading/ReadingActivity.kt
@@ -54,8 +54,6 @@ import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.view.menu.MenuBuilder
 import androidx.appcompat.widget.Toolbar
-import butterknife.BindView
-import butterknife.ButterKnife
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import dagger.hilt.android.AndroidEntryPoint
 import io.reactivex.Scheduler
@@ -69,11 +67,9 @@ import javax.inject.Inject
 @AndroidEntryPoint
 class ReadingActivity : ThemedActivity(), TextToSpeech.OnInitListener {
     @JvmField
-    @BindView(R.id.textViewTitle)
     var mTitle: TextView? = null
 
     @JvmField
-    @BindView(R.id.textViewBody)
     var mBody: TextView? = null
 
 
@@ -115,7 +111,8 @@ class ReadingActivity : ThemedActivity(), TextToSpeech.OnInitListener {
         iTtsEngine = TextToSpeech(this, this)
 
         setContentView(R.layout.reading_view)
-        ButterKnife.bind(this)
+        mTitle = findViewById(R.id.textViewTitle)
+        mBody = findViewById(R.id.textViewBody)
         val toolbar = findViewById<Toolbar>(R.id.toolbar)
         setSupportActionBar(toolbar)
         if (supportActionBar != null) supportActionBar!!.setDisplayHomeAsUpEnabled(true)


### PR DESCRIPTION
Is this really necessary?
View Binding has been supported for a long time and is actively maintained.

ButterKnife is outdated and obsolete.

Existing versions of ButterKnife will of course continue to work, but only critical bug fixes for integration with AGP will be considered.
Development of features and general bug fixes has been discontinued.
From there I see the point of removing this library.