### PR TITLE
Further content blocker improvements

### DIFF
--- a/app/src/main/java/acr/browser/lightning/adblock/AbpBlockerManager.kt
+++ b/app/src/main/java/acr/browser/lightning/adblock/AbpBlockerManager.kt
@@ -204,6 +204,9 @@ class AbpBlockerManager @Inject constructor(
             is BlockResponse -> {
                 return if (request.isForMainFrame)
                     createMainFrameDummy(request.url, response.blockList, response.pattern)
+                else if (contentRequest.type and ContentRequest.TYPE_IMAGE != 0
+                        && contentRequest.type and ContentRequest.TYPE_OTHER == 0) // definitely image
+                    BlockResourceResponse(RES_1X1).toWebResourceResponse()
                 else
                     BlockResourceResponse(RES_EMPTY).toWebResourceResponse()
             }

--- a/app/src/main/java/acr/browser/lightning/adblock/AbpBlockerManager.kt
+++ b/app/src/main/java/acr/browser/lightning/adblock/AbpBlockerManager.kt
@@ -425,8 +425,7 @@ class AbpBlockerManager @Inject constructor(
             //  resp. https://github.com/gorhill/uBlock/wiki/Static-filter-syntax#badfilter
             //  -> if badfilter matches filter only ignoring domains -> remove matching domains from the filter, also match wildcard
             val filters = filterNot {
-                it.second.contentType == ContentRequest.TYPE_POPUP
-                        || badFilterFilters.contains(it.second)
+                badFilterFilters.contains(it.second)
             }
 
             // TODO: remove filters contained in others

--- a/app/src/main/java/acr/browser/lightning/adblock/AbpBlockerManager.kt
+++ b/app/src/main/java/acr/browser/lightning/adblock/AbpBlockerManager.kt
@@ -204,11 +204,14 @@ class AbpBlockerManager @Inject constructor(
             is BlockResponse -> {
                 return if (request.isForMainFrame)
                     createMainFrameDummy(request.url, response.blockList, response.pattern)
-                else if (contentRequest.type and ContentRequest.TYPE_IMAGE != 0
-                        && contentRequest.type and ContentRequest.TYPE_OTHER == 0) // definitely image
-                    BlockResourceResponse(RES_1X1).toWebResourceResponse()
-                else
-                    BlockResourceResponse(RES_EMPTY).toWebResourceResponse()
+                else when(contentRequest.type) {
+                    ContentRequest.TYPE_OTHER -> BlockResourceResponse(RES_EMPTY)
+                    ContentRequest.TYPE_IMAGE -> BlockResourceResponse(RES_1X1)
+                    ContentRequest.TYPE_SUB_DOCUMENT -> BlockResourceResponse(RES_NOOP_HTML)
+                    ContentRequest.TYPE_SCRIPT -> BlockResourceResponse(RES_NOOP_JS)
+                    ContentRequest.TYPE_MEDIA -> BlockResourceResponse(RES_NOOP_MP3)
+                    else -> BlockResourceResponse(RES_EMPTY)
+                }.toWebResourceResponse()
             }
             is BlockResourceResponse -> return response.toWebResourceResponse()
             is ModifyResponse -> {

--- a/app/src/main/java/acr/browser/lightning/adblock/AbpBlockerManager.kt
+++ b/app/src/main/java/acr/browser/lightning/adblock/AbpBlockerManager.kt
@@ -22,7 +22,7 @@ import jp.hazuki.yuzubrowser.adblock.core.AbpLoader
 import jp.hazuki.yuzubrowser.adblock.core.ContentRequest
 import jp.hazuki.yuzubrowser.adblock.core.FilterContainer
 import jp.hazuki.yuzubrowser.adblock.filter.abp.*
-import jp.hazuki.yuzubrowser.adblock.filter.unified.UnifiedFilter
+import jp.hazuki.yuzubrowser.adblock.filter.unified.*
 import jp.hazuki.yuzubrowser.adblock.filter.unified.getFilterDir
 import jp.hazuki.yuzubrowser.adblock.filter.unified.io.FilterReader
 import jp.hazuki.yuzubrowser.adblock.filter.unified.io.FilterWriter
@@ -256,13 +256,16 @@ class AbpBlockerManager @Inject constructor(
     }
 
     // initially based on jp.hazuki.yuzubrowser.adblock/AdBlock.kt
-    private fun is3rdParty(url: Uri, pageHost: String?): Boolean {
-        val hostName = url.host?.lowercase() ?: return true
-        if (pageHost == null) return true
+    private fun is3rdParty(url: Uri, pageHost: String?): Int {
+        val hostName = url.host?.lowercase() ?: return THIRD_PARTY
+        if (pageHost == null) return THIRD_PARTY
 
-        if (hostName == pageHost) return false
+        if (hostName == pageHost) return STRICT_FIRST_PARTY
 
-        return thirdPartyCache["$hostName/$pageHost"]!! // thirdPartyCache.Create can't return null!
+        return if (thirdPartyCache["$hostName/$pageHost"]!!) // thirdPartyCache.Create can't return null!
+            THIRD_PARTY
+        else
+            FIRST_PARTY
     }
 
     // builder part from yuzu: jp.hazuki.yuzubrowser.adblock/AdBlockController.kt

--- a/app/src/main/java/acr/browser/lightning/adblock/AbpBlockerManager.kt
+++ b/app/src/main/java/acr/browser/lightning/adblock/AbpBlockerManager.kt
@@ -250,13 +250,15 @@ class AbpBlockerManager @Inject constructor(
     }
 
     // moved from jp.hazuki.yuzubrowser.adblock/AdBlock.kt to allow modified 3rd party detection
-    private fun WebResourceRequest.getContentRequest(pageUri: Uri) =
-        ContentRequest(url, pageUri, getContentType(pageUri), is3rdParty(url, pageUri), requestHeaders, method)
+    private fun WebResourceRequest.getContentRequest(pageUri: Uri): ContentRequest {
+        val pageHost = pageUri.host?.lowercase()
+        return ContentRequest(url, pageHost, getContentType(pageUri), is3rdParty(url, pageHost), requestHeaders, method)
+    }
 
     // initially based on jp.hazuki.yuzubrowser.adblock/AdBlock.kt
-    private fun is3rdParty(url: Uri, pageUri: Uri): Boolean {
-        val hostName = url.host ?: return true
-        val pageHost = pageUri.host ?: return true
+    private fun is3rdParty(url: Uri, pageHost: String?): Boolean {
+        val hostName = url.host?.lowercase() ?: return true
+        if (pageHost == null) return true
 
         if (hostName == pageHost) return false
 

--- a/app/src/main/java/acr/browser/lightning/adblock/AbpBlockerManager.kt
+++ b/app/src/main/java/acr/browser/lightning/adblock/AbpBlockerManager.kt
@@ -126,7 +126,7 @@ class AbpBlockerManager @Inject constructor(
         // create joint files
         // tags will be created again, this is unnecessary, but fast enough to not care about it very much
         blockerPrefixes.forEach { prefix ->
-            writeFile(prefix, filters[prefix]!!.map { it.second })
+            writeFile(prefix, filters[prefix]!!)
         }
 
         /*if (elementHide) {
@@ -156,16 +156,16 @@ class AbpBlockerManager @Inject constructor(
         return false
     }
 
-    private fun writeFile(prefix: String, filters: Collection<UnifiedFilter>?) {
+    private fun writeFile(prefix: String, filters: Collection<Pair<String, UnifiedFilter>>?) {
         if (filters == null) return // better throw error, should not happen
         val file = File(application.applicationContext.getFilterDir(), prefix)
         val writer = FilterWriter()
         file.outputStream().buffered().use {
             if (isModify(prefix))
             // use !! to get error if filter.modify is null
-                writer.writeModifyFilters(it, filters.toList())
+                writer.writeModifyFiltersWithTag(it, filters.toList())
             else
-                writer.write(it, filters.toList())
+                writer.writeWithTag(it, filters.toList())
             it.close()
         }
     }

--- a/app/src/main/java/acr/browser/lightning/adblock/AbpUserRules.kt
+++ b/app/src/main/java/acr/browser/lightning/adblock/AbpUserRules.kt
@@ -4,6 +4,9 @@ import acr.browser.lightning.database.adblock.UserRulesRepository
 import android.net.Uri
 import jp.hazuki.yuzubrowser.adblock.core.ContentRequest
 import jp.hazuki.yuzubrowser.adblock.filter.unified.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -68,12 +71,12 @@ class AbpUserRules @Inject constructor(
 
     private fun addUserRule(filter: UnifiedFilterResponse) {
         userRules.add(filter)
-        userRulesRepository.addRules(listOf(filter))
+        GlobalScope.launch(Dispatchers.IO) { userRulesRepository.addRules(listOf(filter)) }
     }
 
     private fun removeUserRule(filter: UnifiedFilterResponse) {
         userRules.remove(filter)
-        userRulesRepository.removeRule(filter)
+        GlobalScope.launch(Dispatchers.IO) { userRulesRepository.removeRule(filter) }
     }
 
 /*
@@ -121,7 +124,6 @@ class AbpUserRules @Inject constructor(
     }
 
     fun allowPage(pageUrl: Uri, add: Boolean) {
-        // S4 mini speed test: 1.7 ms for 2nd entry, 26 ms for ~2400th entry -> fast enough, no need to move DB operation to different thread
         val domain = pageUrl.host ?: return
         if (add)
             addUserRule(domain, "", ContentRequest.TYPE_ALL, thirdParty = false, response = false)

--- a/app/src/main/java/acr/browser/lightning/adblock/AbpUserRules.kt
+++ b/app/src/main/java/acr/browser/lightning/adblock/AbpUserRules.kt
@@ -120,7 +120,7 @@ class AbpUserRules @Inject constructor(
     fun isAllowed(pageUrl: Uri): Boolean {
         // TODO: checking by using a fake request might be "slower than necessary"? but sure is faster a than DB query
         //  anyway, this needs to be changed once there can be more rules for a page
-        return userRules.get(ContentRequest(pageUrl, pageUrl, ContentRequest.TYPE_ALL, false, tags = listOf("")))?.response == false
+        return userRules.get(ContentRequest(pageUrl, pageUrl.host, ContentRequest.TYPE_ALL, false, tags = listOf("")))?.response == false
     }
 
     fun allowPage(pageUrl: Uri, add: Boolean) {

--- a/app/src/main/java/acr/browser/lightning/adblock/AbpUserRules.kt
+++ b/app/src/main/java/acr/browser/lightning/adblock/AbpUserRules.kt
@@ -101,9 +101,9 @@ class AbpUserRules @Inject constructor(
 
         // HostFilter for specific request domain, ContainsFilter with empty pattern otherwise
         return if (requestDomain.isEmpty())
-            ContainsFilter(requestDomain, contentType, domains, thirdPartyInt)
+            ContainsFilter(requestDomain, contentType, true, domains, thirdPartyInt)
         else
-            HostFilter(requestDomain, contentType, false, domains, thirdPartyInt)
+            HostFilter(requestDomain, contentType, domains, thirdPartyInt)
     }
 
     fun addUserRule(pageDomain: String, requestDomain: String, contentType: Int, thirdParty: Boolean, response: Boolean?) {

--- a/app/src/main/java/acr/browser/lightning/adblock/AbpUserRules.kt
+++ b/app/src/main/java/acr/browser/lightning/adblock/AbpUserRules.kt
@@ -120,7 +120,7 @@ class AbpUserRules @Inject constructor(
     fun isAllowed(pageUrl: Uri): Boolean {
         // TODO: checking by using a fake request might be "slower than necessary"? but sure is faster a than DB query
         //  anyway, this needs to be changed once there can be more rules for a page
-        return userRules.get(ContentRequest(pageUrl, pageUrl.host, ContentRequest.TYPE_ALL, false, tags = listOf("")))?.response == false
+        return userRules.get(ContentRequest(pageUrl, pageUrl.host, ContentRequest.TYPE_ALL, FIRST_PARTY, tags = listOf("")))?.response == false
     }
 
     fun allowPage(pageUrl: Uri, add: Boolean) {

--- a/app/src/main/java/acr/browser/lightning/adblock/UserFilterContainer.kt
+++ b/app/src/main/java/acr/browser/lightning/adblock/UserFilterContainer.kt
@@ -57,21 +57,17 @@ class UserFilterContainer {
         }
     }
 
-    fun get(contentRequest: ContentRequest): UnifiedFilterResponse? {
+    fun get(request: ContentRequest): UnifiedFilterResponse? {
         // tags are not really used (only pageDomain and empty) -> ignore tags from contentRequest
 
-        // build list of all matching filters
-        // TODO: the mutable list seems avoidable
-        val list = mutableListOf<UnifiedFilterResponse>()
-        filters[""]?.forEach { if (it.filter.isMatch(contentRequest)) list.add(it) }
-        filters[contentRequest.pageUrl.host]?.forEach { if (it.filter.isMatch(contentRequest)) list.add(it) }
+        val matchingFilters = (filters[""] ?: listOf()) + (filters[request.pageUrl.host] ?: listOf())
 
-        if (list.isEmpty()) return null
-        if (allSameResponse(list)) return list.first()
+        if (matchingFilters.isEmpty()) return null
+        if (allSameResponse(matchingFilters)) return matchingFilters.first()
 
         // get the highest priority rule according to uBo criteria (see comments inside filterComparator)
         // TODO: test whether it does what it should
-        return list.maxOfWith(filterComparator, {it})
+        return matchingFilters.maxOfWith(filterComparator, {it})
     }
 
 

--- a/app/src/main/java/acr/browser/lightning/adblock/UserFilterContainer.kt
+++ b/app/src/main/java/acr/browser/lightning/adblock/UserFilterContainer.kt
@@ -60,7 +60,7 @@ class UserFilterContainer {
     fun get(request: ContentRequest): UnifiedFilterResponse? {
         // tags are not really used (only pageDomain and empty) -> ignore tags from contentRequest
 
-        val matchingFilters = (filters[""] ?: listOf()) + (filters[request.pageUrl.host] ?: listOf())
+        val matchingFilters = (filters[""] ?: listOf()) + (filters[request.pageHost] ?: listOf())
 
         if (matchingFilters.isEmpty()) return null
         if (allSameResponse(matchingFilters)) return matchingFilters.first()

--- a/app/src/main/java/acr/browser/lightning/database/adblock/UserRulesDatabase.kt
+++ b/app/src/main/java/acr/browser/lightning/database/adblock/UserRulesDatabase.kt
@@ -11,7 +11,6 @@ import android.database.Cursor
 import android.database.DatabaseUtils
 import android.database.sqlite.SQLiteDatabase
 import android.database.sqlite.SQLiteOpenHelper
-import io.reactivex.Completable
 import jp.hazuki.yuzubrowser.adblock.filter.unified.*
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -88,7 +87,7 @@ class UserRulesDatabase @Inject constructor(
         }
     }
 
-    override fun removeAllRules(): Completable = Completable.fromCallable {
+    override fun removeAllRules() {
         database.run {
             delete(TABLE_RULES, null, null)
             close()

--- a/app/src/main/java/acr/browser/lightning/database/adblock/UserRulesDatabase.kt
+++ b/app/src/main/java/acr/browser/lightning/database/adblock/UserRulesDatabase.kt
@@ -153,14 +153,14 @@ class UserRulesDatabase @Inject constructor(
         val pattern = cursor.getString(cursor.getColumnIndexOrThrow(KEY_PATTERN))
         val filterType = cursor.getInt(cursor.getColumnIndexOrThrow(KEY_FILTER_TYPE))
         val contentType = cursor.getInt(cursor.getColumnIndexOrThrow(KEY_CONTENT_TYPE))
-        val ignoreCase = false
+        val ignoreCase = true
         val thirdParty = cursor.getInt(cursor.getColumnIndexOrThrow(KEY_THIRD_PARTY))
         val domains = cursor.getString(cursor.getColumnIndexOrThrow(KEY_DOMAIN_MAP)).toDomainMap()
 
 
         val filter = when (filterType) { // only recognize filter types that are used in user rules
-            FILTER_TYPE_CONTAINS -> ContainsFilter(pattern, contentType, domains, thirdParty)
-            FILTER_TYPE_HOST -> HostFilter(pattern, contentType, ignoreCase, domains, thirdParty)
+            FILTER_TYPE_CONTAINS -> ContainsFilter(pattern, contentType, ignoreCase, domains, thirdParty)
+            FILTER_TYPE_HOST -> HostFilter(pattern, contentType, domains, thirdParty)
             else -> return null // should not happen -> error message?
         }
         return UnifiedFilterResponse(filter, response)

--- a/app/src/main/java/acr/browser/lightning/database/adblock/UserRulesRepository.kt
+++ b/app/src/main/java/acr/browser/lightning/database/adblock/UserRulesRepository.kt
@@ -1,8 +1,6 @@
 package acr.browser.lightning.database.adblock
 
 import acr.browser.lightning.adblock.UnifiedFilterResponse
-import io.reactivex.Completable
-import io.reactivex.Single
 
 /**
  * A repository that stores [Host].
@@ -13,10 +11,8 @@ interface UserRulesRepository {
 
     /**
      * Remove all hosts in the repository.
-     *
-     * @return A [Completable] that completes when the removal finishes.
      */
-    fun removeAllRules(): Completable
+    fun removeAllRules()
 
     // better use sequence or completable, but currently whatever
     //  sequence is not faster (tested), so no use

--- a/app/src/main/java/jp/hazuki/yuzubrowser/adblock/core/ContentRequest.kt
+++ b/app/src/main/java/jp/hazuki/yuzubrowser/adblock/core/ContentRequest.kt
@@ -21,7 +21,7 @@ import jp.hazuki.yuzubrowser.adblock.filter.unified.Tag
 
 data class ContentRequest(
     val url: Uri,
-    val pageUrl: Uri,
+    val pageHost: String?,
     val type: Int,
     val isThirdParty: Boolean,
     val headers: MutableMap<String, String> = mutableMapOf(),

--- a/app/src/main/java/jp/hazuki/yuzubrowser/adblock/core/ContentRequest.kt
+++ b/app/src/main/java/jp/hazuki/yuzubrowser/adblock/core/ContentRequest.kt
@@ -23,7 +23,7 @@ data class ContentRequest(
     val url: Uri,
     val pageHost: String?,
     val type: Int,
-    val isThirdParty: Boolean,
+    val isThirdParty: Int,
     val headers: MutableMap<String, String> = mutableMapOf(),
     val method: String = "GET",
     val tags: Collection<String> = Tag.create(url.toString()).toSet(),

--- a/app/src/main/java/jp/hazuki/yuzubrowser/adblock/core/ContentRequest.kt
+++ b/app/src/main/java/jp/hazuki/yuzubrowser/adblock/core/ContentRequest.kt
@@ -39,7 +39,7 @@ data class ContentRequest(
         const val TYPE_DOCUMENT = 0x20
         const val TYPE_MEDIA = 0x40
         const val TYPE_FONT = 0x80
-        const val TYPE_POPUP = 0x0100
+        const val TYPE_UNSUPPORTED = 0x0100 // was TYPE_POPUP, now gathers all types that are not (currently) supported
         const val TYPE_WEB_SOCKET = 0x0200
         const val TYPE_XHR = 0x0400
         const val TYPE_ALL = 0xffff

--- a/app/src/main/java/jp/hazuki/yuzubrowser/adblock/core/ContentRequest.kt
+++ b/app/src/main/java/jp/hazuki/yuzubrowser/adblock/core/ContentRequest.kt
@@ -28,6 +28,8 @@ data class ContentRequest(
     val method: String = "GET",
     val tags: Collection<String> = Tag.create(url.toString()).toSet(),
 ) {
+    val urlLowercase = url.lowercase()
+
     companion object {
         const val TYPE_OTHER = 0x01
         const val TYPE_SCRIPT = 0x02
@@ -51,3 +53,10 @@ data class ContentRequest(
         const val TYPE_ELEMENT_GENERIC_HIDE = 0x2000_0000
     }
 }
+
+private fun Uri.lowercase(): Uri =
+    buildUpon()
+        .authority(authority?.lowercase())
+        .path(path?.lowercase())
+        .encodedQuery(encodedQuery?.lowercase())
+        .build()

--- a/app/src/main/java/jp/hazuki/yuzubrowser/adblock/core/CosmeticFiltering.kt
+++ b/app/src/main/java/jp/hazuki/yuzubrowser/adblock/core/CosmeticFiltering.kt
@@ -17,6 +17,7 @@
 package jp.hazuki.yuzubrowser.adblock.core
 
 import android.net.Uri
+import jp.hazuki.yuzubrowser.adblock.filter.unified.FIRST_PARTY
 import jp.hazuki.yuzubrowser.adblock.filter.unified.element.ElementContainer
 
 class CosmeticFiltering(
@@ -29,7 +30,7 @@ class CosmeticFiltering(
     fun loadScript(url: Uri): String? {
         if (cacheUrl == url) return cache
 
-        val request = ContentRequest(url, null, TYPE, false)
+        val request = ContentRequest(url, null, TYPE, FIRST_PARTY)
         val result = disables[request]
 
         val isUseGeneric = when (result?.filterType ?: 0) {

--- a/app/src/main/java/jp/hazuki/yuzubrowser/adblock/core/CosmeticFiltering.kt
+++ b/app/src/main/java/jp/hazuki/yuzubrowser/adblock/core/CosmeticFiltering.kt
@@ -29,7 +29,7 @@ class CosmeticFiltering(
     fun loadScript(url: Uri): String? {
         if (cacheUrl == url) return cache
 
-        val request = ContentRequest(url, url, TYPE, false)
+        val request = ContentRequest(url, null, TYPE, false)
         val result = disables[request]
 
         val isUseGeneric = when (result?.filterType ?: 0) {

--- a/app/src/main/java/jp/hazuki/yuzubrowser/adblock/filter/abp/AbpFilterDecoder.kt
+++ b/app/src/main/java/jp/hazuki/yuzubrowser/adblock/filter/abp/AbpFilterDecoder.kt
@@ -69,7 +69,7 @@ class AbpFilterDecoder {
         val elementFilter = mutableListOf<ElementFilter>()
         val filterLists = FilterMap()
         reader.forEachLine { line ->
-            if (line.isEmpty()) return@forEachLine
+            if (line.isBlank()) return@forEachLine
             val trimmedLine = line.trim()
             when {
                 trimmedLine[0] == '!' -> trimmedLine.decodeComment(url, info)

--- a/app/src/main/java/jp/hazuki/yuzubrowser/adblock/filter/abp/AbpFilterDecoder.kt
+++ b/app/src/main/java/jp/hazuki/yuzubrowser/adblock/filter/abp/AbpFilterDecoder.kt
@@ -246,7 +246,7 @@ class AbpFilterDecoder {
                             "match-case" -> ignoreCase = inverse
                             "domain" -> {
                                 if (value == null) return
-                                domain = value
+                                domain = value.lowercase()
                             }
                             "third-party", "3p" -> thirdParty = if (inverse) FIRST_PARTY else THIRD_PARTY
                             "first-party", "1p" -> thirdParty = if (inverse) THIRD_PARTY else FIRST_PARTY

--- a/app/src/main/java/jp/hazuki/yuzubrowser/adblock/filter/abp/AbpFilterDecoder.kt
+++ b/app/src/main/java/jp/hazuki/yuzubrowser/adblock/filter/abp/AbpFilterDecoder.kt
@@ -384,7 +384,8 @@ class AbpFilterDecoder {
                         isStartsWith -> StartsWithFilter(content, contentType, ignoreCase, domains, thirdParty, modify)
                         isEndWith -> EndWithFilter(content, contentType, ignoreCase, domains, thirdParty, modify)
                         else -> {
-                            if ("http://$content".toUri().host == content) // mimic uBlock behavior: https://github.com/gorhill/uBlock/wiki/Static-filter-syntax#hosts-files
+                            // mimic uBlock behavior: https://github.com/gorhill/uBlock/wiki/Static-filter-syntax#hosts-files
+                            if (this == content && "http://$content".toUri().host == content)
                                 StartEndFilter(content, contentType, ignoreCase, domains, thirdParty, modify)
                             else
                                 ContainsFilter(content, contentType, ignoreCase, domains, thirdParty, modify)

--- a/app/src/main/java/jp/hazuki/yuzubrowser/adblock/filter/abp/AbpFilterDecoder.kt
+++ b/app/src/main/java/jp/hazuki/yuzubrowser/adblock/filter/abp/AbpFilterDecoder.kt
@@ -351,18 +351,7 @@ class AbpFilterDecoder {
                 val isLiteral = content.isLiteralFilter()
                 if (isLiteral) {
                     when {
-                        isStartsWith && isEndWith -> //{
-//                            if (content.contains('.') && !content.contains('/'))
-
- //                       }
-                            StartEndFilter(
-                            content,
-                            contentType,
-                            ignoreCase,
-                            domains,
-                            thirdParty,
-                            modify
-                        )
+                        isStartsWith && isEndWith -> StartEndFilter(content, contentType, ignoreCase, domains, thirdParty, modify)
                         isStartsWith -> StartsWithFilter(content, contentType, ignoreCase, domains, thirdParty, modify)
                         isEndWith -> EndWithFilter(content, contentType, ignoreCase, domains, thirdParty, modify)
                         else -> {

--- a/app/src/main/java/jp/hazuki/yuzubrowser/adblock/filter/mining/MiningProtector.kt
+++ b/app/src/main/java/jp/hazuki/yuzubrowser/adblock/filter/mining/MiningProtector.kt
@@ -24,7 +24,7 @@ import jp.hazuki.yuzubrowser.adblock.filter.unified.HostFilter
 import jp.hazuki.yuzubrowser.adblock.filter.unified.StartsWithFilter
 import java.io.IOException
 import java.io.InputStream
-
+/*
 class MiningProtector {
     val dummy = WebResourceResponse("text/plain", "UTF-8", EmptyInputStream())
 
@@ -95,3 +95,4 @@ class MiningProtector {
         override fun read(): Int = -1
     }
 }
+*/

--- a/app/src/main/java/jp/hazuki/yuzubrowser/adblock/filter/unified/ArrayDomainMap.kt
+++ b/app/src/main/java/jp/hazuki/yuzubrowser/adblock/filter/unified/ArrayDomainMap.kt
@@ -53,4 +53,19 @@ class ArrayDomainMap(size: Int, override var wildcard: Boolean) : SimpleArrayMap
     override fun getValue(index: Int): Boolean {
         return valueAt(index)
     }
+
+    override fun hashCode(): Int {
+        var result = super.hashCode()
+        result = 31 * result + wildcard.hashCode()
+        return result
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        other as ArrayDomainMap
+        if (size != other.size) return false
+        if (wildcard != other.wildcard) return false
+        return super.equals(other as? SimpleArrayMap<String, Boolean>)
+    }
 }

--- a/app/src/main/java/jp/hazuki/yuzubrowser/adblock/filter/unified/ContainsFilter.kt
+++ b/app/src/main/java/jp/hazuki/yuzubrowser/adblock/filter/unified/ContainsFilter.kt
@@ -21,10 +21,11 @@ import android.net.Uri
 class ContainsFilter(
     filter: String,
     contentType: Int,
+    ignoreCase: Boolean,
     domains: DomainMap?,
     thirdParty: Int,
     modify: ModifyFilter? = null
-) : UnifiedFilter(filter, contentType, false, domains, thirdParty, modify) {
+) : UnifiedFilter(filter, contentType, ignoreCase, domains, thirdParty, modify) {
     override val filterType: Int
         get() = FILTER_TYPE_CONTAINS
 

--- a/app/src/main/java/jp/hazuki/yuzubrowser/adblock/filter/unified/ContainsHostFilter.kt
+++ b/app/src/main/java/jp/hazuki/yuzubrowser/adblock/filter/unified/ContainsHostFilter.kt
@@ -21,11 +21,10 @@ import android.net.Uri
 internal class ContainsHostFilter(
     filter: String,
     contentType: Int,
-    ignoreCase: Boolean,
     domains: DomainMap?,
     thirdParty: Int,
     modify: ModifyFilter? = null
-) : UnifiedFilter(filter, contentType, ignoreCase, domains, thirdParty, modify) {
+) : UnifiedFilter(filter, contentType, true, domains, thirdParty, modify) {
     override val filterType: Int
         get() = FILTER_TYPE_CONTAINS_HOST
 

--- a/app/src/main/java/jp/hazuki/yuzubrowser/adblock/filter/unified/EndWithFilter.kt
+++ b/app/src/main/java/jp/hazuki/yuzubrowser/adblock/filter/unified/EndWithFilter.kt
@@ -21,10 +21,11 @@ import android.net.Uri
 class EndWithFilter(
     filter: String,
     contentType: Int,
+    ignoreCase: Boolean,
     domains: DomainMap?,
     thirdParty: Int,
     modify: ModifyFilter? = null
-) : UnifiedFilter(filter, contentType, false, domains, thirdParty, modify) {
+) : UnifiedFilter(filter, contentType, ignoreCase, domains, thirdParty, modify) {
     override val filterType: Int
         get() = FILTER_TYPE_END
 

--- a/app/src/main/java/jp/hazuki/yuzubrowser/adblock/filter/unified/HostFilter.kt
+++ b/app/src/main/java/jp/hazuki/yuzubrowser/adblock/filter/unified/HostFilter.kt
@@ -21,11 +21,10 @@ import android.net.Uri
 internal class HostFilter(
     filter: String,
     contentType: Int,
-    ignoreCase: Boolean,
     domains: DomainMap?,
     thirdParty: Int,
     modify: ModifyFilter? = null
-) : UnifiedFilter(filter, contentType, ignoreCase, domains, thirdParty, modify) {
+) : UnifiedFilter(filter, contentType, true, domains, thirdParty, modify) {
     override val filterType: Int
         get() = FILTER_TYPE_HOST
 

--- a/app/src/main/java/jp/hazuki/yuzubrowser/adblock/filter/unified/ModifyFilter.kt
+++ b/app/src/main/java/jp/hazuki/yuzubrowser/adblock/filter/unified/ModifyFilter.kt
@@ -14,7 +14,10 @@ abstract class ModifyFilter(val parameter: String?, val inverse: Boolean) {
     }
 
     override fun hashCode(): Int {
-        return (parameter + prefix + inverse).hashCode()
+        var result = parameter.hashCode()
+        result = 31 * result + prefix.hashCode()
+        result = 31 * result + inverse.hashCode()
+        return result
     }
 
     companion object {

--- a/app/src/main/java/jp/hazuki/yuzubrowser/adblock/filter/unified/SingleDomainMap.kt
+++ b/app/src/main/java/jp/hazuki/yuzubrowser/adblock/filter/unified/SingleDomainMap.kt
@@ -42,4 +42,18 @@ class SingleDomainMap(override val include: Boolean, private val domain: String)
         if (index != 0) throw IndexOutOfBoundsException()
         return include
     }
+
+    override fun hashCode(): Int {
+        var result = domain.hashCode()
+        result = 31 * result + include.hashCode()
+        return result
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        other as SingleDomainMap
+        if (domain != other.domain) return false
+        return include == other.include
+    }
 }

--- a/app/src/main/java/jp/hazuki/yuzubrowser/adblock/filter/unified/StartEndFilter.kt
+++ b/app/src/main/java/jp/hazuki/yuzubrowser/adblock/filter/unified/StartEndFilter.kt
@@ -31,7 +31,7 @@ class StartEndFilter(
 
     override fun check(url: Uri): Boolean {
         val urlStr = url.schemeSpecificPart
-        val startIndex = urlStr.indexOf(pattern, ignoreCase = ignoreCase)
+        val startIndex = urlStr.indexOf(pattern)
         if (startIndex > -1 && urlStr.checkIsDomainInSsp(startIndex)) {
             return if (pattern.length + startIndex == urlStr.length) {
                 true

--- a/app/src/main/java/jp/hazuki/yuzubrowser/adblock/filter/unified/StartsWithFilter.kt
+++ b/app/src/main/java/jp/hazuki/yuzubrowser/adblock/filter/unified/StartsWithFilter.kt
@@ -31,7 +31,7 @@ class StartsWithFilter(
 
     override fun check(url: Uri): Boolean {
         val path = url.schemeSpecificPart
-        val index = path.indexOf(pattern, ignoreCase = ignoreCase)
+        val index = path.indexOf(pattern)
         if (index > -1) {
             return path.checkIsDomainInSsp(index)
         }

--- a/app/src/main/java/jp/hazuki/yuzubrowser/adblock/filter/unified/Tag.kt
+++ b/app/src/main/java/jp/hazuki/yuzubrowser/adblock/filter/unified/Tag.kt
@@ -41,6 +41,9 @@ object Tag {
                     tags.removeAt(tags.lastIndex)
                 return tags.maxByOrNull { it.length } ?: ""
             }
+            filter is StartEndFilter && filter.pattern.none { it == '/' || it == '*' }
+                    && !filter.pattern.endsWith('.') && filter.pattern.contains('.')
+                    -> return filter.pattern // pattern is a domain
             filter.isRegex -> {
                 // require tags to be between a few selected delimiters
                 //   regex is used like a contains filter and can start in the middle of any string

--- a/app/src/main/java/jp/hazuki/yuzubrowser/adblock/filter/unified/UnifiedFilter.kt
+++ b/app/src/main/java/jp/hazuki/yuzubrowser/adblock/filter/unified/UnifiedFilter.kt
@@ -29,12 +29,16 @@ abstract class UnifiedFilter(
     override val modify: ModifyFilter?
 ) : ContentFilter {
 
+    // careful: for performance reasons, case sensitivity is handled by FilterContainer
     override fun isMatch(request: ContentRequest): Boolean {
         return if ((contentType and request.type) != 0
             && checkThird(request)
             && checkDomain(request.pageUrl.host)
         ) {
-            check(request.url)
+            if (ignoreCase)
+                check(request.urlLowercase)
+            else
+                check(request.url)
         } else {
             false
         }

--- a/app/src/main/java/jp/hazuki/yuzubrowser/adblock/filter/unified/UnifiedFilter.kt
+++ b/app/src/main/java/jp/hazuki/yuzubrowser/adblock/filter/unified/UnifiedFilter.kt
@@ -33,7 +33,7 @@ abstract class UnifiedFilter(
     override fun isMatch(request: ContentRequest): Boolean {
         return if ((contentType and request.type) != 0
             && checkThird(request)
-            && checkDomain(request.pageUrl.host)
+            && checkDomain(request.pageHost)
         ) {
             if (ignoreCase)
                 check(request.urlLowercase)
@@ -51,8 +51,8 @@ abstract class UnifiedFilter(
             NO_PARTY_PREFERENCE -> true // don't care about 3rd party
             FIRST_PARTY -> !request.isThirdParty // match only 1st party
             THIRD_PARTY -> request.isThirdParty // match only 3rd party
-            STRICT_FIRST_PARTY -> request.url.host == request.pageUrl.host // match only strict 1st party (compare fqdn)
-            STRICT_THIRD_PARTY -> request.url.host != request.pageUrl.host // match only strict 3rd party
+            STRICT_FIRST_PARTY -> request.url.host == request.pageHost // match only strict 1st party (compare fqdn)
+            STRICT_THIRD_PARTY -> request.url.host != request.pageHost // match only strict 3rd party
             else -> false // should not happen
         }
 

--- a/app/src/main/java/jp/hazuki/yuzubrowser/adblock/filter/unified/UnifiedFilter.kt
+++ b/app/src/main/java/jp/hazuki/yuzubrowser/adblock/filter/unified/UnifiedFilter.kt
@@ -100,22 +100,8 @@ abstract class UnifiedFilter(
         if (thirdParty != other.thirdParty) return false
         if (filterType != other.filterType) return false
         if (modify != other.modify) return false
-
-        // original domain map comparison not working properly (often returns false for same domains)
-        // -> do more extensive check
-        if (domains == other.domains) return true
-        if (domains?.size != other.domains?.size) return false
-        if (domains?.include != other.domains?.include) return false
-        // now domains must have same size, and are not null -> compare each
-        val d1 = mutableSetOf<String>()
-        val d2 = mutableSetOf<String>()
-        for (i in 0 until domains!!.size) {
-            d1.add(domains!!.getKey(i))
-            d2.add(other.domains!!.getKey(i))
-        }
-        if (d1 == d2) return true
-
-        return false
+        if (domains != other.domains) return false
+        return true
     }
 
     override fun hashCode(): Int {

--- a/app/src/main/java/jp/hazuki/yuzubrowser/adblock/filter/unified/UnifiedFilter.kt
+++ b/app/src/main/java/jp/hazuki/yuzubrowser/adblock/filter/unified/UnifiedFilter.kt
@@ -49,10 +49,10 @@ abstract class UnifiedFilter(
     private fun checkThird(request: ContentRequest): Boolean =
         when (thirdParty) {
             NO_PARTY_PREFERENCE -> true // don't care about 3rd party
-            FIRST_PARTY -> !request.isThirdParty // match only 1st party
-            THIRD_PARTY -> request.isThirdParty // match only 3rd party
-            STRICT_FIRST_PARTY -> request.url.host == request.pageHost // match only strict 1st party (compare fqdn)
-            STRICT_THIRD_PARTY -> request.url.host != request.pageHost // match only strict 3rd party
+            FIRST_PARTY -> request.isThirdParty != THIRD_PARTY // match only 1st party (can be 1st party or strict 1st party)
+            THIRD_PARTY -> request.isThirdParty == THIRD_PARTY // match only 3rd party
+            STRICT_FIRST_PARTY -> request.isThirdParty == STRICT_FIRST_PARTY // match only strict 1st party (compare fqdn)
+            STRICT_THIRD_PARTY -> request.isThirdParty != STRICT_FIRST_PARTY // match all that is not strict 1st party
             else -> false // should not happen
         }
 

--- a/app/src/main/java/jp/hazuki/yuzubrowser/adblock/filter/unified/io/FilterReader.kt
+++ b/app/src/main/java/jp/hazuki/yuzubrowser/adblock/filter/unified/io/FilterReader.kt
@@ -173,11 +173,11 @@ class FilterReader(private val input: InputStream) {
             }
 
         val filter = when (type) {
-            FILTER_TYPE_CONTAINS -> ContainsFilter(pattern, contentType, domains, thirdParty, modify)
-            FILTER_TYPE_HOST -> HostFilter(pattern, contentType, ignoreCase, domains, thirdParty, modify)
-            FILTER_TYPE_CONTAINS_HOST -> ContainsHostFilter(pattern, contentType, ignoreCase, domains, thirdParty, modify)
+            FILTER_TYPE_CONTAINS -> ContainsFilter(pattern, contentType, ignoreCase, domains, thirdParty, modify)
+            FILTER_TYPE_HOST -> HostFilter(pattern, contentType, domains, thirdParty, modify)
+            FILTER_TYPE_CONTAINS_HOST -> ContainsHostFilter(pattern, contentType, domains, thirdParty, modify)
             FILTER_TYPE_START -> StartsWithFilter(pattern, contentType, ignoreCase, domains, thirdParty, modify)
-            FILTER_TYPE_END -> EndWithFilter(pattern, contentType, domains, thirdParty, modify)
+            FILTER_TYPE_END -> EndWithFilter(pattern, contentType, ignoreCase, domains, thirdParty, modify)
             FILTER_TYPE_START_END -> StartEndFilter(pattern, contentType, ignoreCase, domains, thirdParty, modify)
             FILTER_TYPE_JVM_REGEX -> RegexFilter(pattern, contentType, ignoreCase, domains, thirdParty, modify)
             FILTER_TYPE_JVM_REGEX_HOST -> RegexHostFilter(pattern, contentType, ignoreCase, domains, thirdParty, modify)

--- a/app/src/main/java/jp/hazuki/yuzubrowser/adblock/filter/unified/io/FilterWriter.kt
+++ b/app/src/main/java/jp/hazuki/yuzubrowser/adblock/filter/unified/io/FilterWriter.kt
@@ -68,7 +68,7 @@ class FilterWriter {
 
         filters.forEach {
             val modify = it.second.modify ?: return@forEach // log if null?
-            val modifyString = "" + modify.prefix + (if (modify.inverse) 1 else 0) + modify.parameter
+            val modifyString = "" + modify.prefix + (if (modify.inverse) 1 else 0) + (modify.parameter ?: "")
             writeModify(os, modifyString)
             writeFilter(os, it)
         }

--- a/app/src/test/java/acr/browser/lightning/adblock/AbpBlockerTest.kt
+++ b/app/src/test/java/acr/browser/lightning/adblock/AbpBlockerTest.kt
@@ -240,7 +240,7 @@ class AbpBlockerTest {
 
     @Test
     fun modifyFiltersReadWrite() {
-        val startList = set2.filters[ABP_PREFIX_MODIFY]
+        val startList = set2.filters[ABP_PREFIX_MODIFY] + set2.filters[ABP_PREFIX_MODIFY_EXCEPTION]
         val filterStore = ByteArrayOutputStream()
         filterStore.use {
             val writer = FilterWriter()

--- a/app/src/test/java/acr/browser/lightning/adblock/AbpBlockerTest.kt
+++ b/app/src/test/java/acr/browser/lightning/adblock/AbpBlockerTest.kt
@@ -116,15 +116,15 @@ class AbpBlockerTest {
         loadFiltersIntoContainers(filterList.joinToString("\n").byteInputStream())
 
         blockedRequests?.forEach {
-            println("should be blocked: " + it.url + " " + it.pageUrl)
+            println("should be blocked: " + it.url + " " + it.pageHost)
             Assert.assertTrue(blocker.shouldBlock(it) is BlockResponse)
         }
         allowedRequests?.forEach {
-            println("should not be blocked: " + it.url + " " + it.pageUrl)
+            println("should not be blocked: " + it.url + " " + it.pageHost)
             Assert.assertNull(blocker.shouldBlock(it))
         }
         modifiedRequests?.forEach {
-            println("should be modified: " + it.url + " " + it.pageUrl)
+            println("should be modified: " + it.url + " " + it.pageHost)
             Assert.assertTrue(blocker.shouldBlock(it) is BlockResourceResponse || blocker.shouldBlock(it) is ModifyResponse)
         }
     }
@@ -160,11 +160,11 @@ class AbpBlockerTest {
             }
 
         blockedRequests.forEach {
-            println("should be filtered: " + it.url + " " + it.pageUrl)
+            println("should be filtered: " + it.url + " " + it.pageHost)
             Assert.assertNotNull(container[it])
         }
         allowedRequests.forEach {
-            println("should not be touched: " + it.url + " " + it.pageUrl)
+            println("should not be touched: " + it.url + " " + it.pageHost)
             Assert.assertNull(container[it])
         }
     }
@@ -542,7 +542,7 @@ class AbpBlockerTest {
             Assert.assertEquals(response.addResponseHeaders?.get("Content-Security-Policy"), "font-src *")
         }
         allowedRequests.forEach {
-            println("should not be touched: " + it.url + " " + it.pageUrl)
+            println("should not be touched: " + it.url + " " + it.pageHost)
             Assert.assertNull(blocker.shouldBlock(it))
         }
     }
@@ -743,7 +743,7 @@ class AbpBlockerTest {
     }
 
     private fun WebResourceRequest.getContentRequest(pageUri: Uri) =
-        ContentRequest(url, pageUri, getContentType(pageUri), is3rdParty(url, pageUri), requestHeaders, "GET")
+        ContentRequest(url, pageUri.host, getContentType(pageUri), is3rdParty(url, pageUri), requestHeaders, "GET")
 
     // should be same code as in AdBlock.kt, but with mimeTypeMap[extension] instead of getMimeTypeFromExtension(extension)
     // because mimetypemap not working in tests

--- a/app/src/test/java/acr/browser/lightning/adblock/AbpBlockerTest.kt
+++ b/app/src/test/java/acr/browser/lightning/adblock/AbpBlockerTest.kt
@@ -677,7 +677,19 @@ class AbpBlockerTest {
         filterList.add("||example.com^\$important")
         blockedRequests.add(request("http://example.com/something.gif", "https://goodotherpage.com"))
         checkFiltersWithBlocker(filterList, blockedRequests, allowedRequests, null)
+    }
 
+    @Test
+    fun denyallow() {
+        val filterList = mutableListOf<String>()
+        val blockedRequests = mutableListOf<ContentRequest>()
+        val allowedRequests = mutableListOf<ContentRequest>()
+
+        filterList.add("*\$denyallow=page1.com|page2.com,domain=page3.com|page4.com")
+        blockedRequests.add(request("http://page.com/something.gif", "https://page3.com"))
+        allowedRequests.add(request("http://page1.com/something.gif", "https://page3.com"))
+
+        checkFiltersWithBlocker(filterList, blockedRequests, allowedRequests, null)
     }
 
     @Test

--- a/app/src/test/java/acr/browser/lightning/adblock/AbpBlockerTest.kt
+++ b/app/src/test/java/acr/browser/lightning/adblock/AbpBlockerTest.kt
@@ -442,6 +442,33 @@ class AbpBlockerTest {
     }
 
     @Test
+    fun matchCase() {
+        val filterList = mutableListOf<String>()
+        val blockedRequests = mutableListOf<ContentRequest>()
+        val allowedRequests = mutableListOf<ContentRequest>()
+        filterList.add("||page.com/ads")
+        blockedRequests.add(request("http://page.com/ads", "https://page.com"))
+        blockedRequests.add(request("http://page.com/ADS", "https://page.com"))
+        filterList.add("||page2.com/Ads\$match-case")
+        blockedRequests.add(request("http://page2.com/Ads", "https://page.com"))
+        allowedRequests.add(request("http://page2.com/ads", "https://page.com"))
+        filterList.add("page3/ads")
+        blockedRequests.add(request("http://page3.com/page3/Ads", "https://page.com"))
+        blockedRequests.add(request("http://page3.com/page3/ads", "https://page.com"))
+        filterList.add("page4/Ads\$match-case")
+        blockedRequests.add(request("http://page4.com/page4/Ads", "https://page.com"))
+        allowedRequests.add(request("http://page4.com/page4/ads", "https://page.com"))
+        filterList.add("page5*/Ads\$match-case")
+        blockedRequests.add(request("http://page5.com/page5b/Ads", "https://page.com"))
+        allowedRequests.add(request("http://page5.com/page5b/ads", "https://page.com"))
+        filterList.add("page6*/Ads")
+        blockedRequests.add(request("http://page5.com/page6b/Ads", "https://page.com"))
+        blockedRequests.add(request("http://page5.com/page6b/ads", "https://page.com"))
+
+        checkFiltersWithBlocker(filterList, blockedRequests, allowedRequests, null)
+    }
+
+    @Test
     fun removeparam() {
         // only tests removeparam so far
         val filterList = mutableListOf<String>()

--- a/app/src/test/java/acr/browser/lightning/adblock/AbpBlockerTest.kt
+++ b/app/src/test/java/acr/browser/lightning/adblock/AbpBlockerTest.kt
@@ -815,19 +815,22 @@ class TestWebResourceRequest(private val url2: Uri,
     override fun getMethod() = "GET" // not needed, but should be valid
 }
 
-fun is3rdParty(url: Uri, pageUri: Uri): Boolean {
-    val hostName = url.host ?: return true
-    val pageHost = pageUri.host ?: return true
+fun is3rdParty(url: Uri, pageUri: Uri): Int {
+    val hostName = url.host?.lowercase() ?: return THIRD_PARTY
+    val pageHost = pageUri.host ?: return THIRD_PARTY
 
-    if (hostName == pageHost) return false
+    if (hostName == pageHost) return STRICT_FIRST_PARTY
 
     val ipPattern = PatternsCompat.IP_ADDRESS
     if (ipPattern.matcher(hostName).matches() || ipPattern.matcher(pageHost).matches())
-        return true
+        return THIRD_PARTY
 
     val db = PublicSuffix.get()
 
-    return db.getEffectiveTldPlusOne(hostName) != db.getEffectiveTldPlusOne(pageHost)
+    return if (db.getEffectiveTldPlusOne(hostName) != db.getEffectiveTldPlusOne(pageHost))
+        THIRD_PARTY
+    else
+        FIRST_PARTY
 }
 
 

--- a/app/src/test/java/acr/browser/lightning/adblock/AbpUserRulesTest.kt
+++ b/app/src/test/java/acr/browser/lightning/adblock/AbpUserRulesTest.kt
@@ -1,0 +1,27 @@
+package acr.browser.lightning.adblock
+
+import acr.browser.lightning.database.adblock.UserRulesRepository
+import androidx.core.net.toUri
+import org.junit.Assert
+import org.junit.Test
+
+class AbpUserRulesTest {
+    private val abpUserRules = AbpUserRules(NoUserRulesRepository())
+
+    @Test
+    fun block() {
+        abpUserRules.allowPage("http://page.com/something".toUri(), add = true)
+        // now page.com should be explicitly allowlisted
+        Assert.assertTrue(abpUserRules.isAllowed("http://page.com/otherthing".toUri()))
+        Assert.assertFalse(abpUserRules.isAllowed("http://page2.com/otherthing".toUri()))
+        Assert.assertFalse(abpUserRules.isAllowed("http://test.page.com/otherthing".toUri()))
+    }
+
+}
+
+private class NoUserRulesRepository: UserRulesRepository {
+    override fun addRules(rules: List<UnifiedFilterResponse>) {}
+    override fun removeAllRules() {}
+    override fun removeRule(rule: UnifiedFilterResponse) {}
+    override fun getAllRules() = listOf<UnifiedFilterResponse>()
+}

--- a/app/src/test/java/jp/hazuki/yuzubrowser/adblock/filter/unified/ContainsFilterTest.kt
+++ b/app/src/test/java/jp/hazuki/yuzubrowser/adblock/filter/unified/ContainsFilterTest.kt
@@ -29,6 +29,6 @@ class ContainsFilterTest {
         val uri = mock(Uri::class.java)
         whenever(uri.toString()).thenReturn("http://blog.livedoor.jp/dqnplus/settings/lite2/ads.js")
 
-        assertThat(ContainsFilter("/lite2/ads.js", ContentRequest.TYPE_ALL, null, -1).check(uri)).isEqualTo(true)
+        assertThat(ContainsFilter("/lite2/ads.js", ContentRequest.TYPE_ALL, true, null, -1).check(uri)).isEqualTo(true)
     }
 }


### PR DESCRIPTION
Some more (mostly) small improvements and fixes:
* By default, filters should not be case sensitive. There a $match-case filter rule to explicitely change this.
I was a bit surprised when I noticed that the blocker actually is case sensitive. So this is fixed now: everything is changed to lower case unless $match-case is involved.
* ContentRequest now contains full third party information (for [strict1p/3p](https://github.com/gorhill/uBlock/wiki/Static-filter-syntax#strict1p)), lower case url (for case insensitive filters), and pageHost instead of pageUrl (because only host is ever used). This should reduce repeated function calls when checking filters, especially getting lowercase url.
* filter tags can be domain in more cases (reduces unnecessary checks)
* [denyallow](https://kb.adguard.com/en/general/how-to-create-your-own-ad-filters#denyallow) is implemented
* exceptions for modify filters were not stored correctly

Unit tests are passing, but I did not do much testing on a real device. So probably waiting a day or so before merging would be a good idea.