### PR TITLE
Show link in long click menu

### DIFF
--- a/app/src/main/java/acr/browser/lightning/dialog/DialogItem.kt
+++ b/app/src/main/java/acr/browser/lightning/dialog/DialogItem.kt
@@ -16,6 +16,7 @@ class DialogItem(
     val colorTint: Int? = null,
     @param:StringRes
     val title: Int,
+    val titleString: String? = null,
     val show: Boolean = true,
     private val onClick: () -> Unit
 ) {

--- a/app/src/main/java/acr/browser/lightning/dialog/LightningDialogBuilder.kt
+++ b/app/src/main/java/acr/browser/lightning/dialog/LightningDialogBuilder.kt
@@ -354,8 +354,13 @@ class LightningDialogBuilder @Inject constructor(
         showImageTab: Boolean
     ) = BrowserDialog.show(activity, "", false,
         //Link tab
-        DialogTab(show=showLinkTab, icon=R.drawable.ic_link, title=R.string.button_link,items=arrayOf(DialogItem(title = R.string.dialog_open_new_tab) {
-            uiController.handleNewTab(NewTab.FOREGROUND, linkUrl)
+        DialogTab(show=showLinkTab, icon=R.drawable.ic_link, title=R.string.button_link,items=arrayOf(
+            DialogItem(title = 0, titleString = linkUrl) {
+                clipboardManager.copyToClipboard(linkUrl)
+                activity.snackbar(R.string.message_link_copied)
+            },
+            DialogItem(title = R.string.dialog_open_new_tab) {
+                uiController.handleNewTab(NewTab.FOREGROUND, linkUrl)
             },
             DialogItem(title = R.string.dialog_open_background_tab) {
                 uiController.handleNewTab(NewTab.BACKGROUND, linkUrl)
@@ -369,10 +374,6 @@ class LightningDialogBuilder @Inject constructor(
             DialogItem(title = R.string.action_share) {
                 IntentUtils(activity).shareUrl(linkUrl, null)
             },
-            DialogItem(title = R.string.dialog_copy_link) {
-                clipboardManager.copyToClipboard(linkUrl)
-                activity.snackbar(R.string.message_link_copied)
-            },
             // Show copy text dialog item if we have some text
             DialogItem(title = R.string.dialog_copy_text, show = !text.isNullOrEmpty()) {
                 if (!text.isNullOrEmpty()) {
@@ -382,9 +383,14 @@ class LightningDialogBuilder @Inject constructor(
             })),
         // Image tab
         DialogTab(show=showImageTab, icon=R.drawable.ic_image, title = R.string.button_image,
-            items = arrayOf(DialogItem(title = R.string.dialog_open_new_tab) {
+            items = arrayOf(
+                DialogItem(title = 0, titleString = imageUrl) {
+                    clipboardManager.copyToClipboard(imageUrl)
+                    activity.snackbar(R.string.message_link_copied)
+                },
+                DialogItem(title = R.string.dialog_open_new_tab) {
                 uiController.handleNewTab(NewTab.FOREGROUND, imageUrl)
-            },
+                },
                 DialogItem(title = R.string.dialog_open_background_tab) {
                     uiController.handleNewTab(NewTab.BACKGROUND, imageUrl)
                 },
@@ -396,10 +402,6 @@ class LightningDialogBuilder @Inject constructor(
                 },
                 DialogItem(title = R.string.action_share) {
                     IntentUtils(activity).shareUrl(imageUrl, null)
-                },
-                DialogItem(title = R.string.dialog_copy_link) {
-                    clipboardManager.copyToClipboard(imageUrl)
-                    activity.snackbar(R.string.message_link_copied)
                 },
                 DialogItem(title = R.string.dialog_download_image,
                     // Do not show download option for data URL as we don't support that for now

--- a/app/src/main/java/acr/browser/lightning/dialog/TabsPagerAdapter.kt
+++ b/app/src/main/java/acr/browser/lightning/dialog/TabsPagerAdapter.kt
@@ -49,7 +49,7 @@ class TabsPagerAdapter(
         // Populate our list with our items
         val recyclerView = view.findViewById<RecyclerView>(R.id.dialog_list)
         val itemList = tabs[position].iItems.filter(DialogItem::show)
-        val adapter = RecyclerViewStringAdapter(itemList, convertToString = { context.getString(this.title) })
+        val adapter = RecyclerViewStringAdapter(itemList, convertToString = { this.titleString ?: context.getString(this.title) })
         recyclerView.apply {
             layoutManager = LinearLayoutManager(context, RecyclerView.VERTICAL, false)
             this.adapter = adapter

--- a/app/src/main/java/acr/browser/lightning/list/RecyclerViewStringAdapter.kt
+++ b/app/src/main/java/acr/browser/lightning/list/RecyclerViewStringAdapter.kt
@@ -2,6 +2,7 @@ package acr.browser.lightning.list
 
 import acr.browser.lightning.R
 import acr.browser.lightning.extensions.inflater
+import android.text.TextUtils
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
@@ -26,6 +27,8 @@ class RecyclerViewStringAdapter<T>(
 
     override fun onBindViewHolder(holder: SimpleStringViewHolder, position: Int) {
         val item = listItems[position]
+        holder.title.maxLines = 2
+        holder.title.ellipsize = TextUtils.TruncateAt.END
         holder.title.text = item.convertToString()
         holder.itemView.setOnClickListener { onItemClickListener?.invoke(item) }
     }


### PR DESCRIPTION
fixes #349

Displays the link / image url as first item in long click menu, limited to 2 lines of text.
Url is copied on click, and the "copy link" menu item that does the same is removed. Reasoning is that a user who wants to copy the link would try clicking the url. Or maybe "copy link" should remain a separate item? Not sure...

I don't really like the added `titleString` in `DialogItem`... ideally `DialogItem` would require exacly one of them
@Slion maybe you have a better idea how to add ability to set a string?