### PR TITLE
fix crash when decoding malformatted regex filters

### DIFF
--- a/app/src/main/java/jp/hazuki/yuzubrowser/adblock/filter/abp/AbpFilterDecoder.kt
+++ b/app/src/main/java/jp/hazuki/yuzubrowser/adblock/filter/abp/AbpFilterDecoder.kt
@@ -372,7 +372,8 @@ class AbpFilterDecoder {
 
         val abpFilter =
             if (filter.length >= 2 && filter[0] == '/' && filter[filter.lastIndex] == '/' && filter.mayContainRegexChars()) {
-                RegexFilter(filter.substring(1, filter.lastIndex), contentType, ignoreCase, domains, thirdParty, modify)
+                try { RegexFilter(filter.substring(1, filter.lastIndex), contentType, ignoreCase, domains, thirdParty, modify) }
+                catch (e: Exception) { return }
             } else {
                 val isStartsWith = filter.startsWith("||")
                 val isEndWith = filter.endsWith('^')


### PR DESCRIPTION
There is a blocklist with a bad regex filter around, and decoding should not crash the browser.
I checked whether the other filters could crash on decoding, but concluded they should be ok.