### PR TITLE
Custom user agent adaditional checks / Intent-Activity refactor ...

### DIFF
--- a/.github/workflows/build-main-fulguris-download.yml
+++ b/.github/workflows/build-main-fulguris-download.yml
@@ -8,7 +8,6 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
@@ -21,5 +20,12 @@ jobs:
 
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
+
     - name: Build Slions download variants
       run: ./gradlew assembleSlionsFullDownload
+
+    - name: Upload Build Artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: slions-full-download
+        path: app/build/outputs/**

--- a/app/src/main/java/fulguris/settings/preferences/DomainPreferences.kt
+++ b/app/src/main/java/fulguris/settings/preferences/DomainPreferences.kt
@@ -161,7 +161,7 @@ class DomainPreferences constructor(
      * - Ask: Ask the user whether or not to launch the app
      */
     var launchAppOverride by preferences.booleanPreference(R.string.pref_key_launch_app_override, false)
-    var launchAppLocal by preferences.enumPreference(R.string.pref_key_launch_app, NoYesAsk.ASK)
+    var launchAppLocal by preferences.enumPreference(R.string.pref_key_launch_app, NoYesAsk.YES)
     val launchAppParent: NoYesAsk get() { return parent?.launchApp ?: launchAppLocal}
     val launchApp: NoYesAsk get() { return if (isDefault || !launchAppOverride) { launchAppParent } else { launchAppLocal } }
 

--- a/app/src/main/java/fulguris/settings/preferences/DomainPreferences.kt
+++ b/app/src/main/java/fulguris/settings/preferences/DomainPreferences.kt
@@ -161,7 +161,7 @@ class DomainPreferences constructor(
      * - Ask: Ask the user whether or not to launch the app
      */
     var launchAppOverride by preferences.booleanPreference(R.string.pref_key_launch_app_override, false)
-    var launchAppLocal by preferences.enumPreference(R.string.pref_key_launch_app, NoYesAsk.NO)
+    var launchAppLocal by preferences.enumPreference(R.string.pref_key_launch_app, NoYesAsk.ASK)
     val launchAppParent: NoYesAsk get() { return parent?.launchApp ?: launchAppLocal}
     val launchApp: NoYesAsk get() { return if (isDefault || !launchAppOverride) { launchAppParent } else { launchAppLocal } }
 

--- a/app/src/main/java/fulguris/settings/preferences/UserPreferencesExtensions.kt
+++ b/app/src/main/java/fulguris/settings/preferences/UserPreferencesExtensions.kt
@@ -30,7 +30,10 @@ fun UserPreferences.userAgent(application: Application): String =
         USER_AGENT_IOS_MOBILE -> IOS_MOBILE_USER_AGENT
         USER_AGENT_SYSTEM -> System.getProperty("http.agent") ?: " "
         USER_AGENT_WEB_VIEW -> WebSettings.getDefaultUserAgent(application)
-        USER_AGENT_CUSTOM -> userAgentString.takeIf(String::isNotEmpty) ?: " "
+        USER_AGENT_CUSTOM -> userAgentString
+            .takeIf { it.isNotEmpty() }
+            ?.replace(Regex("[\r\n]"), "")
+            ?: " "
         USER_AGENT_HIDE_DEVICE -> "Mozilla/5.0 (Linux; Android ${Build.VERSION.RELEASE})" +
                 webViewEngineVersion(application)
         else -> throw UnsupportedOperationException("Unknown userAgentChoice: $choice")

--- a/app/src/main/java/fulguris/utils/IntentUtils.java
+++ b/app/src/main/java/fulguris/utils/IntentUtils.java
@@ -6,19 +6,26 @@ import android.content.IntentFilter;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.net.Uri;
+import android.net.MailTo;
+import androidx.core.content.FileProvider;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 
 import android.util.Log;
 import android.webkit.WebView;
+import android.webkit.MimeTypeMap;
+import android.webkit.URLUtil;
 
+import java.io.File;
 import java.net.URISyntaxException;
 import java.util.List;
+import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import fulguris.R;
+import fulguris.BuildConfig;
 import fulguris.constant.Constants;
 
 public class IntentUtils {
@@ -55,46 +62,68 @@ public class IntentUtils {
         intent.setComponent(null);
         intent.setSelector(null);
 
-        if (mActivity.getPackageManager().resolveActivity(intent, 0) == null) {
-            // SL: Not sure what that special case is for
-            String packagename = intent.getPackage();
-            if (packagename != null) {
-                intent = new Intent(Intent.ACTION_VIEW, Uri.parse("market://search?q=pname:"
-                        + packagename));
-                intent.addCategory(Intent.CATEGORY_BROWSABLE);
-                //mActivity.startActivity(intent);
-                return intent;
-            } else {
-                return null;
-            }
-        }
         if (tab != null) {
             intent.putExtra(Constants.INTENT_ORIGIN, tab.hashCode());
         }
 
-        Matcher m = ACCEPTED_URI_SCHEMA.matcher(url);
-        if (m.matches() && !isSpecializedHandlerAvailable(intent)) {
+        if (ACCEPTED_URI_SCHEMA.matcher(url).matches() && !isSpecializedHandlerAvailable(intent)) {
             return null;
         }
 
         return intent;
     }
 
+    private Intent handleUnresolvableIntent(Intent intent) {
+        String packageName = intent.getPackage();
+        if (packageName != null) {
+            Uri marketUri = Uri.parse("market://search?q=pname:" + packageName);
+            Intent marketIntent = new Intent(Intent.ACTION_VIEW, marketUri);
+            marketIntent.addCategory(Intent.CATEGORY_BROWSABLE);
+            return marketIntent;
+        }
+        return null;
+    }
+
     public boolean startActivityForIntent(Intent aIntent) {
-            try {
-                if (mActivity.startActivityIfNeeded(aIntent, -1)) {
-                    return true;
-                }
-            } catch (Exception exception) {
-                exception.printStackTrace();
-                // TODO: 6/5/17 fix case where this could throw a FileUriExposedException due to file:// urls
+        if (mActivity.getPackageManager().resolveActivity(aIntent, 0) == null) {
+                aIntent = handleUnresolvableIntent(aIntent);
+        }
+
+        try {
+            if (mActivity.startActivityIfNeeded(aIntent, -1)) {
+                return true;
             }
+        } catch (Exception exception) {
+            exception.printStackTrace();
+            // TODO: 6/5/17 fix case where this could throw a FileUriExposedException due to file:// urls
+        }
         return false;
     }
 
     public boolean startActivityForUrl(@Nullable WebView tab, @NonNull String url) {
         Intent intent = intentForUrl(tab,url);
         return startActivityForIntent(intent);
+    }
+
+    public boolean startActivityWithFallback(@Nullable WebView tab, @NonNull Intent intent, boolean onlyFallback) {
+        if (!onlyFallback && startActivityForIntent(intent)) {
+            Log.d("IntentUtils", "Intent successfully started.");
+            // Intent was successfully handled
+            return true;
+        } else {
+            Log.d("IntentUtils", "Failed to start intent, checking for fallback URL.");
+            // Check for a fallback URL if the intent could not be started
+            String fallbackUrl = intent.getStringExtra("browser_fallback_url");
+            if (fallbackUrl != null && !fallbackUrl.isEmpty()) {
+                Log.d("IntentUtils", "Fallback URL found: " + fallbackUrl);
+                if (tab != null) {
+                    tab.loadUrl(fallbackUrl);
+                }
+                return true;
+            }
+            Log.d("IntentUtils", "No fallback URL found.");
+        }
+        return false;
     }
 
     /**
@@ -128,6 +157,68 @@ public class IntentUtils {
             return true;
         }
         return false;
+    }
+
+    /**
+     * Handles URLs with special schemes such as mailto, tel, and intent by creating
+     * and returning an appropriate Intent based on the scheme. This method also handles
+     * file URLs by creating an Intent to open the file. If the URL does not match any
+     * special scheme or if an error occurs (e.g., URISyntaxException), null is returned.
+     *
+     * @param activity The Activity context used to access package manager and resources.
+     * @param url The URL to be handled. It can be a special scheme URL or a file URL.
+     * @param view The WebView that may be used for additional context or actions.
+     * @return An Intent that corresponds to the action required by the URL's scheme,
+     *         or null if the URL does not match a special scheme or an error occurs.
+     */
+    public Intent handleSpecialSchemes(Activity activity, String url, WebView view) {
+        Uri uri = Uri.parse(url);
+        Log.d("IntentUtils", "Handling special schemes for URL: " + url);
+        String scheme = uri.getScheme().toLowerCase(Locale.ROOT);
+        Log.d("IntentUtils", "Detected scheme: " + scheme);
+        switch (scheme) {
+            case "mailto":
+                Log.d("IntentUtils", "Detected mailto scheme.");
+                MailTo mailTo = MailTo.parse(url);
+                return fulguris.utils.Utils.newEmailIntent(mailTo.getTo(), mailTo.getSubject(), mailTo.getBody(), mailTo.getCc());
+            case "tel":
+                Log.d("IntentUtils", "Detected tel scheme.");
+                Intent intentTel = new Intent(Intent.ACTION_DIAL);
+                intentTel.setData(Uri.parse(url));
+                return intentTel;
+            case "intent":
+                try {
+                    Log.d("IntentUtils", "Detected intent scheme.");
+                    Intent intent = Intent.parseUri(url, Intent.URI_INTENT_SCHEME);
+                    intent.addCategory(Intent.CATEGORY_BROWSABLE);
+                    intent.setComponent(null);
+                    intent.setSelector(null);
+                    return intent;
+                } catch (URISyntaxException e) {
+                    Log.e("IntentUtils", "URISyntaxException for URL: " + url, e);
+                    return null;
+                }
+            default:
+                if (URLUtil.isFileUrl(url) && !UrlUtils.isSpecialUrl(url)) {
+                    Log.d("IntentUtils", "Detected file URL.");
+                    File file = new File(url.replace("file://", ""));
+                    if (file.exists()) {
+                        String newMimeType = MimeTypeMap.getSingleton()
+                                .getMimeTypeFromExtension(fulguris.utils.Utils.guessFileExtension(file.toString()));
+                        Intent intentFile = new Intent(Intent.ACTION_VIEW);
+                        intentFile.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+                        Uri contentUri = FileProvider.getUriForFile(activity, BuildConfig.APPLICATION_ID + ".fileprovider", file);
+                        intentFile.setDataAndType(contentUri, newMimeType);
+                        return intentFile;
+                    } else {
+                        Log.d("IntentUtils", "File not found for URL: " + url);
+                        // Handle file not found scenario
+                        return null;
+                    }
+                }
+                Log.d("IntentUtils", "No special handling required for URL: " + url);
+                return null;
+        }
     }
 
     /**

--- a/app/src/main/java/fulguris/view/WebPageClient.kt
+++ b/app/src/main/java/fulguris/view/WebPageClient.kt
@@ -622,8 +622,6 @@ class WebPageClient(
         }
 
         loadDomainPreferences(uri.host ?: "", false)
-        Timber.d("Stack 0")
-
 
         val customIntent = intentUtils.handleSpecialSchemes(activity, url, view)
         if (handleExternalAppIntent(view, customIntent)) {
@@ -631,15 +629,11 @@ class WebPageClient(
             return true
         }
 
-        Timber.d("Stack 1")
-
         val intentUrl = intentUtils.intentForUrl(view, url)
         if (handleExternalAppIntent(view, intentUrl)) {
             Timber.d("intentForUrl: $intentUrl")
             return true
         }
-
-        Timber.d("Stack 2")
 
         // If none of the special conditions was met, continue with loading the url
         return continueLoadingUrl(view, url, headers)


### PR DESCRIPTION
Hi, thanks for the project! I made some changes, to make Fulguris better. Changes are:

 - Additional custom user agent check for new line breaks and tabulator. Fixes:
```
java.lang.IllegalArgumentException: HTTP headers must not contain null, CR, or NL characters. Invalid User-Agent 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36 Edg/122.0.2365.92
```

- Make asking to run an external application by default. This has been a big problem for me. I used Fulguris for a while, but every time I get a weird bug with not opening intents. And once I deleted Fulguris because of that. Now I understand that it was because the apps opening flag was disabled by default in the domain settings.

- Major refactor of the intent logic. Fixes #595. Also can now handle `browser_fallback_url' param. This param value of the URL will be opened if there is no activity available. Some other minor fixes. 