### PR TITLE
Handle new intent when a link is shared from another app using long press

### DIFF
--- a/app/src/main/java/fulguris/browser/TabsManager.kt
+++ b/app/src/main/java/fulguris/browser/TabsManager.kt
@@ -273,6 +273,15 @@ class TabsManager @Inject constructor(
     }
 
     /**
+     *
+     */
+    private fun launchNewTabAndActivate(url: String) {
+        newTab(UrlInitializer(url), true)
+        shouldClose = true
+        lastTab()?.isNewTab = true
+    }
+
+    /**
      * Initialize the state of the [TabsManager] based on previous state of the browser.
      *
      * TODO: See how you can offload IO to a background thread
@@ -1114,8 +1123,14 @@ class TabsManager @Inject constructor(
             if ("text/plain" == intent.type) {
                 // Get shared text
                 val clue = intent.getStringExtra(Intent.EXTRA_TEXT)
-                // Put it in the address bar if any
-                clue?.let { iWebBrowser.setAddressBarText(it) }
+
+                //Fix for #628 - Handle when a link is long pressed on another app and shared to Fulguris
+                if (clue != null && URLUtil.isNetworkUrl(clue.trim())) {
+                    launchNewTabAndActivate(clue)
+                } else {
+                    // Put it in the address bar if any
+                    clue?.let { iWebBrowser.setAddressBarText(it) }
+                }
             }
             // Cancel other operation as we won't open a tab here
             null
@@ -1135,9 +1150,7 @@ class TabsManager @Inject constructor(
                     lastTab()?.isNewTab = true
                 }
             } else {
-                newTab(UrlInitializer(url), true)
-                shouldClose = true
-                lastTab()?.isNewTab = true
+                launchNewTabAndActivate(url)
             }
         }
     }


### PR DESCRIPTION
Fixes #628

Scenario: From another browser app or any app, long press a link and share to fulguris.
Before changes: Fulguris will fill the URL in current tab's address bar and wait for user to press enter
With changes: Fulguris opens a new tab and loads the URL directly.

I am not sure on the purpose of 'getTabForHashCode' that's below the changed lines. I can try further modification if you can suggest any change for this diff.