### PR TITLE
feat(onboarding): integrate browser settings slide into intro flow

### DIFF
--- a/app/src/main/java/fulguris/activity/IntroActivity.kt
+++ b/app/src/main/java/fulguris/activity/IntroActivity.kt
@@ -16,6 +16,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import fulguris.R
 import fulguris.fragment.AcceptTermsSlideFragment
 import fulguris.fragment.AdBlockerSlideFragment
+import fulguris.fragment.ConfigurationSlideFragment
 import fulguris.fragment.TelemetrySlideFragment
 import timber.log.Timber
 
@@ -81,6 +82,8 @@ class IntroActivity : AppIntro2() {
         }
         // Add ad blocker slide
         addSlide(AdBlockerSlideFragment.newInstance())
+        // Add configuration slide
+        addSlide(ConfigurationSlideFragment.newInstance())
         // TODO: Could add a variant specific slide here
 
         // Request notification permission on the permissions slide (Android 13+)

--- a/app/src/main/java/fulguris/fragment/ConfigurationPreferenceFragment.kt
+++ b/app/src/main/java/fulguris/fragment/ConfigurationPreferenceFragment.kt
@@ -1,0 +1,66 @@
+package fulguris.fragment
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.preference.PreferenceFragmentCompat
+import fulguris.R
+import fulguris.activity.IntroActivity
+import timber.log.Timber
+
+/**
+ * Preference page for configuration onboarding
+ * Used by our app intro onboarding activity slide
+ */
+class ConfigurationPreferenceFragment: PreferenceFragmentCompat() {
+
+    // Track the delayed navigation task so it can be cancelled if user toggles switch back
+    private val pendingNavigation = Runnable {
+        Timber.d("Executing delayed navigation to next slide")
+        (activity as? IntroActivity)?.nextSlide()
+    }
+
+    override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+        Timber.d("ConfigurationPreferenceFragment")
+        setPreferencesFromResource(R.xml.preference_configuration_intro, rootKey)
+
+        // Set up listener for configuration toggle
+        setupConfigurationListener()
+    }
+
+    private fun setupConfigurationListener() {
+        // Listen for changes to the configuration switch
+        findPreference<slions.pref.SwitchPreference>(getString(R.string.pref_key_configuration))?.setOnPreferenceChangeListener { _, newValue ->
+            // Cancel any pending navigation
+            view?.removeCallbacks(pendingNavigation)
+
+//            // When user enables configuration, automatically advance to next slide
+//            if (newValue == true) {
+//                Timber.d("User enabled configuration, scheduling navigation to next slide")
+//                // Post with delay to allow the preference animation to complete
+//                view?.postDelayed(pendingNavigation, 500)
+//            } else {
+//                Timber.d("User disabled configuration")
+//            }
+            true
+        }
+    }
+
+    override fun onPause() {
+        super.onPause()
+        // Cancel pending navigation when user navigates away from this slide
+        view?.removeCallbacks(pendingNavigation)
+        Timber.d("onPause: Cancelled pending navigation")
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        return super.onCreateView(inflater, container, savedInstanceState)
+    }
+
+    override fun onDestroyView() {
+        // Clean up any pending navigation when view is destroyed
+        view?.removeCallbacks(pendingNavigation)
+        super.onDestroyView()
+    }
+}

--- a/app/src/main/java/fulguris/fragment/ConfigurationSlideFragment.kt
+++ b/app/src/main/java/fulguris/fragment/ConfigurationSlideFragment.kt
@@ -1,0 +1,62 @@
+package fulguris.fragment
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updateLayoutParams
+import androidx.fragment.app.Fragment
+import com.github.appintro.SlideBackgroundColorHolder
+import dagger.hilt.android.AndroidEntryPoint
+import fulguris.R
+
+/**
+ * App onboarding intro slide for configuration options
+ * Hosts ConfigurationPreferenceFragment and handles system bars clearance
+ */
+@AndroidEntryPoint
+class ConfigurationSlideFragment: Fragment(), SlideBackgroundColorHolder {
+
+    // SlideBackgroundColorHolder implementation
+    @Deprecated("Use defaultBackgroundColorRes instead")
+    override var defaultBackgroundColor: Int = 0
+
+    override var defaultBackgroundColorRes: Int = R.color.md_theme_dark_onTertiary
+
+    override fun setBackgroundColor(backgroundColor: Int) {
+        view?.setBackgroundColor(backgroundColor)
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? = inflater.inflate(R.layout.slide_intro_configuration, container, false)
+
+    // Handle window insets to avoid overlap with status bar
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+
+        val content = view.findViewById<View>(R.id.content)
+        ViewCompat.setOnApplyWindowInsetsListener(content) { view, insets ->
+            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            // Apply margin to our inner page content so that we clear the system bars while still applying background color to them
+            view.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+                topMargin = systemBars.top
+                bottomMargin = systemBars.bottom
+                leftMargin = systemBars.left
+                rightMargin = systemBars.right
+            }
+            insets
+        }
+
+        super.onViewCreated(view, savedInstanceState)
+    }
+
+    companion object {
+        fun newInstance() : ConfigurationSlideFragment {
+            return ConfigurationSlideFragment()
+        }
+    }
+}

--- a/app/src/main/res/layout/slide_intro_configuration.xml
+++ b/app/src/main/res/layout/slide_intro_configuration.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:tools="http://schemas.android.com/tools"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:paddingTop="@dimen/appintro_statusbar_height"
+        android:paddingBottom="@dimen/appintro2_bottombar_height"
+        >
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:id="@+id/content">
+
+            <TextView
+                android:id="@+id/title"
+                style="@style/AppIntroDefaultHeading"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:gravity="center"
+                android:text="@string/intro_title_configuration"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintBottom_toTopOf="@+id/fragmentContainerView"
+                app:layout_constraintVertical_weight="2" />
+
+            <androidx.fragment.app.FragmentContainerView
+                android:id="@+id/fragmentContainerView"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:name="fulguris.fragment.ConfigurationPreferenceFragment"
+                android:paddingStart="2dp"
+                android:paddingEnd="2dp"
+                app:layout_constraintTop_toBottomOf="@+id/title"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintWidth_max="400dp"
+                app:layout_constraintVertical_weight="8" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </FrameLayout>
+
+</layout>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -95,6 +95,7 @@
     <string name="pref_key_webrtc">pref_key_webrtc</string>
     <string name="pref_key_content_control">pref_key_content_control</string>
     <string name="pref_key_content_control_filters">pref_key_content_control_filters</string>
+    <string name="pref_key_configuration">pref_key_configuration</string>
     <string name="pref_key_delete_all_domains_settings">pref_key_delete_all_domains_settings</string>
 
     <string name="pref_key_search_in_new_tab">pref_key_search_in_new_tab</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -711,6 +711,12 @@ See: https://stackoverflow.com/a/42884713/3969362
     <string name="intro_welcome_description">Experience fast, secure, and customizable web browsing with advanced privacy features and modern design.</string>
     <string name="intro_title_terms">Let\'s Get Started!</string>
     <string name="intro_title_telemetry">Help Us, Help You!</string>
+    <string name="intro_title_configuration">Configure Your Experience</string>
+    <string name="intro_description_configuration">Customize your browser settings to match your preferences. You can always change these later in the settings menu.</string>
+
+    <string name="pref_title_enable_configuration">Configuration options</string>
+    <string name="pref_summary_on_enable_configuration">Enjoy a personalized browsing experience</string>
+    <string name="pref_summary_off_enable_configuration">Use default browser settings</string>
     <string name="intro_title_ad_blocker">Be Safe!</string>
     <string name="intro_description_ad_blocker">Enable our powerful ad blocker to browse faster, safer, and with fewer distractions. You can always change this later in settings.</string>
     <string name="intro_notification_permission_title">Notification permission</string>

--- a/app/src/main/res/xml/preference_configuration_intro.xml
+++ b/app/src/main/res/xml/preference_configuration_intro.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+This is loaded and displayed by our configuration onboarding intro slide.
+It is not intended to be shown in application menu or settings.
+Should only be shown on first application start-up.
+-->
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <Preference
+        android:key="configuration_description"
+        android:title="@string/intro_description_configuration"
+        android:selectable="false"
+        app:iconSpaceReserved="false"
+        app:singleLineTitle="false" />
+
+    <slions.pref.SwitchPreference
+        android:key="@string/pref_key_configuration"
+        android:title="@string/pref_title_enable_configuration"
+        android:summaryOn="@string/pref_summary_on_enable_configuration"
+        android:summaryOff="@string/pref_summary_off_enable_configuration"
+        app:icon="@drawable/ic_settings"
+        android:defaultValue="false"
+        app:iconSpaceReserved="true"
+        app:singleLineTitle="false" />
+
+</PreferenceScreen>


### PR DESCRIPTION
Introduce a new slide in the onboarding process that lets users personalize browser options right from the start. This includes adding relevant string keys and UI text for slide content and preference toggles.